### PR TITLE
PR 14: Implementation of Issue #2.3 - Meal Participation for Employees

### DIFF
--- a/Task2_mhp_discord-bot/.gitignore
+++ b/Task2_mhp_discord-bot/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log*
 .coverage
 htmlcov/
 .pytest_cache/
+tests/

--- a/Task2_mhp_discord-bot/backend/src/handlers/auth.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/auth.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from src.config import settings
 from src.models import UserRole
+from src.services.discord_helpers import extract_team_from_roles
 
 logger = logging.getLogger(__name__)
 
@@ -62,11 +63,14 @@ def get_user_from_interaction(interaction: dict) -> AuthenticatedUser:
     guild_id = member.get("guild_id") or interaction.get("guild_id", "")
     
     # Map Discord roles to application role
-    app_role, team = map_discord_roles_to_app_role(discord_roles)
+    app_role, _ = map_discord_roles_to_app_role(discord_roles)
+    
+    # Derive team from Discord roles via DynamoDB policy (team_role_map)
+    team = extract_team_from_roles(discord_roles)
     
     logger.info(
         f"Authenticated user: {username} ({discord_id}) - Role: {app_role.value}, "
-        f"Discord roles: {discord_roles}"
+        f"Team: {team}, Discord roles: {discord_roles}"
     )
     
     return AuthenticatedUser(

--- a/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
@@ -15,6 +15,11 @@ from src.handlers.auth import (
     get_user_from_interaction as auth_get_user,
     check_command_authorization,
 )
+from src.handlers.meal_handler import (
+    handle_meal_update,
+    handle_meal_toggle,
+    MEAL_TOGGLE_PREFIX,
+)
 from src.models import UserRole
 
 logger = logging.getLogger(__name__)
@@ -129,7 +134,10 @@ def route_command(interaction: Dict[str, Any], user: AuthenticatedUser) -> Dict[
     if not is_authorized:
         return create_error_response(error_msg)
     
-    # Placeholder response - feature handlers will be added in subsequent issues
+    if command_name == "meal-update":
+        return handle_meal_update(interaction, user)
+    
+    # Placeholder response for unimplemented commands
     return {
         "type": RESPONSE_CHANNEL_MESSAGE,
         "data": {
@@ -137,9 +145,14 @@ def route_command(interaction: Dict[str, Any], user: AuthenticatedUser) -> Dict[
             "flags": 64  # Ephemeral
         }
     }
-
-
 def handle_component_interaction(interaction: Dict[str, Any], user: AuthenticatedUser) -> Dict[str, Any]:
+    data = interaction.get("data", {})
+    custom_id = data.get("custom_id", "")
+    
+    if custom_id.startswith(MEAL_TOGGLE_PREFIX):
+        return handle_meal_toggle(interaction, user)
+    
+    # Placeholder for unhandled component interactions
     return {
         "type": RESPONSE_CHANNEL_MESSAGE,
         "data": {

--- a/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
@@ -8,7 +8,6 @@ from nacl.signing import VerifyKey
 from nacl.encoding import RawEncoder
 
 from src.config import settings
-from src.services.discord_helpers import extract_team_from_roles
 
 from src.handlers.auth import (
     AuthenticatedUser,
@@ -88,22 +87,6 @@ def parse_interaction(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse JSON: {e}")
         return None
-
-
-def get_user_from_interaction(interaction: Dict[str, Any]) -> Dict[str, Any]:
-    
-    member = interaction.get("member", {})
-    user = interaction.get("user", {})
-    roles = member.get("roles", [])
-    
-    return {
-        "id": member.get("user", {}).get("id") or user.get("id", ""),
-        "username": member.get("user", {}).get("username") or user.get("username", ""),
-        "global_name": member.get("user", {}).get("global_name") or user.get("global_name"),
-        "roles": roles,
-        "team": extract_team_from_roles(roles),
-        "guild_id": member.get("guild_id") or interaction.get("guild_id", ""),
-    }
 
 
 def get_command_name(interaction: Dict[str, Any]) -> str:

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -103,3 +103,55 @@ def _build_meal_toggle_buttons(
     return rows
 
 
+def handle_meal_update(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    try:
+        options = _get_command_options(interaction)
+        date_str = options.get("date")
+
+        try:
+            target_date = parse_date_option(date_str)
+        except ValueError as e:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": f"❌ {str(e)}",
+                    "flags": 64,
+                },
+            }
+
+        is_valid, error_msg = validate_date_for_update(target_date)
+        if not is_valid:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": f"❌ {error_msg}",
+                    "flags": 64,
+                },
+            }
+
+        embed = _build_meal_status_embed(user.discord_id, target_date)
+        components = _build_meal_toggle_buttons(user.discord_id, target_date)
+
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "embeds": [embed],
+                "components": components,
+                "flags": 64,  # Ephemeral
+            },
+        }
+
+    except Exception as e:
+        logger.exception(f"Error handling meal-update: {e}")
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": "❌ An error occurred while fetching your meal status. Please try again.",
+                "flags": 64,
+            },
+        }
+
+
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -154,4 +154,85 @@ def handle_meal_update(
         }
 
 
+def handle_meal_toggle(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    try:
+        data = interaction.get("data", {})
+        custom_id = data.get("custom_id", "")
 
+        # Parse custom_id: meal_toggle:<discord_id>:<date>:<meal_type>
+        parts = custom_id.split(":")
+        if len(parts) != 4 or parts[0] != MEAL_TOGGLE_PREFIX:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": "❌ Invalid button interaction.",
+                    "flags": 64,
+                },
+            }
+
+        _, target_user_id, date_str, meal_type_str = parts
+
+        # Security: ensure the clicking user matches the button target
+        if user.discord_id != target_user_id:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": "❌ You can only update your own meal participation.",
+                    "flags": 64,
+                },
+            }
+
+        target_date = date.fromisoformat(date_str)
+        meal_type = MealType(meal_type_str)
+
+        # Toggle
+        success, result = meal_service.toggle_meal_participation(
+            discord_id=user.discord_id,
+            target_date=target_date,
+            meal_type=meal_type,
+            updated_by=user.discord_id,
+        )
+
+        if not success:
+            # result is an error message string
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": f"❌ {result}",
+                    "flags": 64,
+                },
+            }
+
+        # Build updated embed + buttons showing new state
+        embed = _build_meal_status_embed(user.discord_id, target_date)
+        components = _build_meal_toggle_buttons(user.discord_id, target_date)
+
+        # Add confirmation text to embed description
+        display = meal_service.get_meal_display_info(meal_type)
+        status_text = "✅ Opted In" if result.is_participating else "❌ Opted Out"
+        embed["description"] = (
+            f"📅 **{format_date_display(target_date)}**\n\n"
+            f"Updated **{display['emoji']} {display['label']}** → {status_text}\n\n"
+            f"Click a button below to toggle your participation for each meal."
+        )
+
+        # Use UPDATE_MESSAGE to edit the original response in place
+        return {
+            "type": RESPONSE_UPDATE_MESSAGE,
+            "data": {
+                "embeds": [embed],
+                "components": components,
+            },
+        }
+
+    except Exception as e:
+        logger.exception(f"Error handling meal toggle: {e}")
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": "❌ An error occurred while updating your meal status. Please try again.",
+                "flags": 64,
+            },
+        }

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -27,4 +27,79 @@ BUTTON_DANGER = 4     # Red (opted out)
 # Custom ID prefix for meal toggle buttons
 MEAL_TOGGLE_PREFIX = "meal_toggle"
 
+def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
+    data = interaction.get("data", {})
+    options = data.get("options", [])
+    return {opt["name"]: opt["value"] for opt in options}
+
+
+def _build_meal_status_embed(
+    discord_id: str, target_date: date
+) -> Dict[str, Any]:
+    meals = meal_service.get_user_meals_for_date(discord_id, target_date)
+
+    fields = []
+    for meal_type, record in meals.items():
+        display = meal_service.get_meal_display_info(meal_type)
+        is_participating = meal_service.get_participation_status(record)
+
+        status_emoji = "✅" if is_participating else "❌"
+        status_text = "Opted In" if is_participating else "Opted Out"
+
+        fields.append({
+            "name": f"{display['emoji']} {display['label']}",
+            "value": f"{status_emoji} {status_text}",
+            "inline": True,
+        })
+
+    embed = {
+        "title": "🍽️ Meal Participation",
+        "description": f"📅 **{format_date_display(target_date)}**\n\nClick a button below to toggle your participation for each meal.",
+        "fields": fields,
+        "color": 0x5865F2,  # Discord blurple
+        "footer": {
+            "text": "Default: Opted In for all meals • Toggle to change"
+        },
+    }
+
+    return embed
+
+
+def _build_meal_toggle_buttons(
+    discord_id: str, target_date: date
+) -> list[Dict[str, Any]]:
+    meals = meal_service.get_user_meals_for_date(discord_id, target_date)
+
+    buttons = []
+    for meal_type, record in meals.items():
+        display = meal_service.get_meal_display_info(meal_type)
+        is_participating = meal_service.get_participation_status(record)
+
+        # custom_id format: meal_toggle:<discord_id>:<date>:<meal_type>
+        custom_id = f"{MEAL_TOGGLE_PREFIX}:{discord_id}:{target_date.isoformat()}:{meal_type.value}"
+
+        if is_participating:
+            style = BUTTON_SUCCESS
+            label = f"{display['emoji']} {display['label']} ✅"
+        else:
+            style = BUTTON_DANGER
+            label = f"{display['emoji']} {display['label']} ❌"
+
+        buttons.append({
+            "type": BUTTON,
+            "style": style,
+            "label": label,
+            "custom_id": custom_id,
+        })
+
+    # Discord allows max 5 buttons per action row
+    rows = []
+    for i in range(0, len(buttons), 5):
+        rows.append({
+            "type": ACTION_ROW,
+            "components": buttons[i:i + 5],
+        })
+
+    return rows
+
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -1,0 +1,30 @@
+# Handles /meal-update slash command and meal toggle button interactions
+import logging
+from datetime import date
+from typing import Any, Dict
+
+from src.handlers.auth import AuthenticatedUser
+from src.models import MealType
+from src.services.meal_service import meal_service, MEAL_DISPLAY
+from src.utils import parse_date_option, format_date_display, validate_date_for_update
+
+logger = logging.getLogger(__name__)
+
+# Discord response types
+RESPONSE_CHANNEL_MESSAGE = 4
+RESPONSE_UPDATE_MESSAGE = 7
+
+# Discord component types
+ACTION_ROW = 1
+BUTTON = 2
+
+# Discord button styles
+BUTTON_PRIMARY = 1    # Blurple (opted in)
+BUTTON_SECONDARY = 2  # Grey
+BUTTON_SUCCESS = 3    # Green (opted in)
+BUTTON_DANGER = 4     # Red (opted out)
+
+# Custom ID prefix for meal toggle buttons
+MEAL_TOGGLE_PREFIX = "meal_toggle"
+
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -193,6 +193,7 @@ def handle_meal_toggle(
             target_date=target_date,
             meal_type=meal_type,
             updated_by=user.discord_id,
+            team=user.team,
         )
 
         if not success:

--- a/Task2_mhp_discord-bot/backend/src/services/__init__.py
+++ b/Task2_mhp_discord-bot/backend/src/services/__init__.py
@@ -1,0 +1,1 @@
+# Services layer

--- a/Task2_mhp_discord-bot/backend/src/services/meal_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/meal_service.py
@@ -51,6 +51,7 @@ class MealService:
         target_date: date,
         meal_type: MealType,
         updated_by: str | None = None,
+        team: str | None = None,
     ) -> tuple[bool, MealParticipation | str]:
         # Validate date
         is_valid, error_msg = validate_date_for_update(target_date)
@@ -74,6 +75,7 @@ class MealService:
             meal_type=meal_type,
             date=target_date,
             is_participating=new_status,
+            team=team,
             updated_by=updated_by or discord_id,
             updated_at=now,
         )

--- a/Task2_mhp_discord-bot/backend/src/services/meal_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/meal_service.py
@@ -1,0 +1,103 @@
+# Business logic for meal participation CRUD + validation
+import logging
+from datetime import date, datetime
+
+from src.config import settings
+from src.models import MealParticipation, MealType
+from src.storage.dynamodb import DynamoDBStorage, storage as default_storage
+from src.utils import validate_date_for_update, DHAKA_UTC_OFFSET
+
+logger = logging.getLogger(__name__)
+
+# Default meal types available for daily participation
+DEFAULT_MEAL_TYPES: list[MealType] = [
+    MealType.LUNCH,
+    MealType.SNACKS,
+]
+
+# Meal type display names and emoji
+MEAL_DISPLAY = {
+    MealType.LUNCH: {"label": "Lunch", "emoji": "🍱"},
+    MealType.SNACKS: {"label": "Snacks", "emoji": "🍕"},
+    MealType.IFTAR: {"label": "Iftar", "emoji": "🌙"},
+    MealType.EVENT_DINNER: {"label": "Event Dinner", "emoji": "🎉"},
+    MealType.OPTIONAL_DINNER: {"label": "Optional Dinner", "emoji": "🍽️"},
+}
+
+
+class MealService:
+
+    def __init__(self, storage: DynamoDBStorage = None):
+        self.storage = storage or default_storage
+
+    def get_available_meal_types(self) -> list[MealType]:
+        return list(DEFAULT_MEAL_TYPES)
+
+    def get_user_meals_for_date(
+        self, discord_id: str, target_date: date
+    ) -> dict[MealType, MealParticipation | None]:
+        meal_types = self.get_available_meal_types()
+        result: dict[MealType, MealParticipation | None] = {}
+
+        for meal_type in meal_types:
+            record = self.storage.get_meal(discord_id, target_date, meal_type)
+            result[meal_type] = record
+
+        return result
+
+    def toggle_meal_participation(
+        self,
+        discord_id: str,
+        target_date: date,
+        meal_type: MealType,
+        updated_by: str | None = None,
+    ) -> tuple[bool, MealParticipation | str]:
+        # Validate date
+        is_valid, error_msg = validate_date_for_update(target_date)
+        if not is_valid:
+            return False, error_msg
+
+        # Get current status
+        existing = self.storage.get_meal(discord_id, target_date, meal_type)
+
+        if existing:
+            # Toggle: flip is_participating
+            new_status = not existing.is_participating
+        else:
+            # No record exists → default is opted-in → toggling means opt-out
+            new_status = False
+
+        now = datetime.now(DHAKA_UTC_OFFSET)
+
+        meal = MealParticipation(
+            user_id=discord_id,
+            meal_type=meal_type,
+            date=target_date,
+            is_participating=new_status,
+            updated_by=updated_by or discord_id,
+            updated_at=now,
+        )
+
+        self.storage.put_meal(meal)
+
+        status_text = "opted in" if new_status else "opted out"
+        logger.info(
+            f"Meal toggled: user={discord_id}, date={target_date}, "
+            f"meal={meal_type.value}, status={status_text}"
+        )
+
+        return True, meal
+
+    def get_participation_status(
+        self, record: MealParticipation | None
+    ) -> bool:
+        if record is None:
+            return True
+        return record.is_participating
+
+    def get_meal_display_info(self, meal_type: MealType) -> dict:
+        return MEAL_DISPLAY.get(
+            meal_type,
+            {"label": meal_type.value.replace("_", " ").title(), "emoji": "🍽️"},
+        )
+meal_service = MealService()

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -1,0 +1,20 @@
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Asia/Dhaka is UTC+6 (no DST)
+DHAKA_UTC_OFFSET = timezone(timedelta(hours=6))
+
+
+def get_dhaka_now() -> datetime:
+    return datetime.now(DHAKA_UTC_OFFSET)
+
+
+def get_dhaka_today() -> date:
+    return get_dhaka_now().date()
+
+
+

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -41,5 +41,34 @@ def is_within_forward_window(target_date: date) -> bool:
     max_date = today + timedelta(days=settings.FORWARD_PLANNING_DAYS)
     return target_date <= max_date
 
+def validate_date_for_update(target_date: date) -> tuple[bool, str | None]:
+    if is_past_date(target_date):
+        return False, "Cannot update past dates. Please select today or a future date."
+
+    if is_past_cutoff(target_date):
+        return False, (
+            f"Updates for {target_date.isoformat()} are closed. "
+            f"The cutoff time is {settings.CUTOFF_TIME} (Asia/Dhaka)."
+        )
+
+    if not is_within_forward_window(target_date):
+        return False, (
+            f"Cannot update dates more than {settings.FORWARD_PLANNING_DAYS} days ahead. "
+            f"Maximum allowed date: {(get_dhaka_today() + timedelta(days=settings.FORWARD_PLANNING_DAYS)).isoformat()}."
+        )
+
+    return True, None
 
 
+def parse_date_option(date_str: str | None) -> date:
+    if not date_str:
+        return get_dhaka_today()
+
+    try:
+        return date.fromisoformat(date_str)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid date format: '{date_str}'. Use YYYY-MM-DD.")
+
+
+def format_date_display(d: date) -> str:
+    return d.strftime("%A, %B %d, %Y")  # e.g. "Wednesday, March 04, 2026"

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -17,8 +17,41 @@ def get_dhaka_today() -> date:
     return get_dhaka_now().date()
 
 
+_DEFAULT_CUTOFF_HOUR = 21
+_DEFAULT_CUTOFF_MINUTE = 0
+
+
+def _parse_cutoff_time(raw: str) -> tuple[int, int]:
+    parts = raw.split(":")
+    if len(parts) != 2:
+        logger.warning(
+            "Malformed CUTOFF_TIME '%s' (expected HH:MM). Falling back to %02d:%02d.",
+            raw, _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE,
+        )
+        return _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE
+
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+    except ValueError:
+        logger.warning(
+            "Non-numeric CUTOFF_TIME '%s'. Falling back to %02d:%02d.",
+            raw, _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE,
+        )
+        return _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE
+
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        logger.warning(
+            "CUTOFF_TIME '%s' out of range (hour 0-23, minute 0-59). "
+            "Falling back to %02d:%02d.",
+            raw, _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE,
+        )
+        return _DEFAULT_CUTOFF_HOUR, _DEFAULT_CUTOFF_MINUTE
+
+    return hour, minute
+
+
 def get_cutoff_datetime(target_date: date) -> datetime:
-    hour, minute = map(int, settings.CUTOFF_TIME.split(":"))
+    hour, minute = _parse_cutoff_time(settings.CUTOFF_TIME)
     return datetime(
         target_date.year, target_date.month, target_date.day,
         hour, minute, 0,

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -17,4 +17,29 @@ def get_dhaka_today() -> date:
     return get_dhaka_now().date()
 
 
+def get_cutoff_datetime(target_date: date) -> datetime:
+    hour, minute = map(int, settings.CUTOFF_TIME.split(":"))
+    return datetime(
+        target_date.year, target_date.month, target_date.day,
+        hour, minute, 0,
+        tzinfo=DHAKA_UTC_OFFSET,
+    )
+
+
+def is_past_cutoff(target_date: date) -> bool:
+    now = get_dhaka_now()
+    cutoff = get_cutoff_datetime(target_date)
+    return now >= cutoff
+
+
+def is_past_date(target_date: date) -> bool:
+    return target_date < get_dhaka_today()
+
+
+def is_within_forward_window(target_date: date) -> bool:
+    today = get_dhaka_today()
+    max_date = today + timedelta(days=settings.FORWARD_PLANNING_DAYS)
+    return target_date <= max_date
+
+
 


### PR DESCRIPTION
## Related Issues
* Fixes #22

## Summary
Implements the `/meal-update` slash command, allowing employees to view and toggle their meal participation per meal type for a given date via interactive Discord buttons. Includes the services layer, date/time utilities, and interaction routing.

## Dependencies

- #41 (docs/issue3/Meal-Participation — documentation PR)

## Changes
- Add `src/utils.py` — Asia/Dhaka timezone helpers, cutoff time parsing with validation and fallback, date validation (past date, cutoff, forward window), date parsing and formatting
- Add `src/services/meal_service.py` — `MealService` with meal type management, per-user meal status queries, toggle participation with cutoff/date validation, display info helpers
- Add `src/handlers/meal_handler.py` — `/meal-update` command handler (embed + button builder), `meal_toggle` button interaction handler (toggle + UPDATE_MESSAGE), custom ID format `meal_toggle:{discord_id}:{date}:{meal_type}` with user-match security check
- Modify `src/handlers/interaction.py` — Route `meal-update` command to `handle_meal_update`; route `meal_toggle:*` component interactions to `handle_meal_toggle`

## Context
Issue #22 is the core employee-facing feature. Employees need a quick way to see their current meal status and toggle participation per meal type within the cutoff window. This builds on the infrastructure (#20) and auth (#21) layers, adding the first feature-complete vertical slice: command → service → storage → interactive response.

Key behaviors:
- Default participation is **opted-in** for all meals; employees toggle to opt out
- Cutoff validation rejects updates after 21:00 Asia/Dhaka (configurable, with safe parsing fallback)
- Past dates and dates beyond the 7-day forward window are rejected
- Button clicks update the message in place (Discord `UPDATE_MESSAGE` type 7)
- Users can only toggle their own buttons (discord_id match enforced)

## How to Test (if applicable)
Create a mock test file that: 
1. Invokes locally with a `/meal-update` interaction payload (no date param → defaults to today)
2. Verify response contains an embed with meal types and green toggle buttons
3. Send a component interaction with `custom_id: meal_toggle:{user_id}:{date}:lunch` and verify the meal record toggles in DynamoDB and the response is `type: 7` with updated embed/buttons
4. Verify past dates and post-cutoff dates return clear error messages
5. Verify a mismatched `discord_id` in the button custom_id is rejected

## Checklist (select options which are applicable)
- [x] Code builds successfully
- [ ] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes