### PR TITLE
PR 18: Admin/Team Lead Override for Meal Participation & Work Location (Issue #2.5)

### DIFF
--- a/Task2_mhp_discord-bot/backend/src/handlers/auth.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/auth.py
@@ -103,7 +103,7 @@ COMMAND_ROLE_REQUIREMENTS = {
     "work-location": UserRole.EMPLOYEE,
     "team-summary": UserRole.TEAM_LEAD,
     "headcount-summary": UserRole.ADMIN,
-    "override-update": UserRole.ADMIN,
+    "override-update": UserRole.TEAM_LEAD,
     "generate-summary": UserRole.ADMIN,
 }
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/interaction.py
@@ -24,6 +24,13 @@ from src.handlers.location_handler import (
     handle_location_set,
     LOCATION_SET_PREFIX,
 )
+from src.handlers.override_handler import (
+    handle_override_update,
+    handle_override_meal,
+    handle_override_location,
+    OVERRIDE_MEAL_PREFIX,
+    OVERRIDE_LOC_PREFIX,
+)
 from src.models import UserRole
 
 logger = logging.getLogger(__name__)
@@ -128,6 +135,9 @@ def route_command(interaction: Dict[str, Any], user: AuthenticatedUser) -> Dict[
     if command_name == "work-location":
         return handle_work_location(interaction, user)
     
+    if command_name == "override-update":
+        return handle_override_update(interaction, user)
+    
     # Placeholder response for unimplemented commands
     return {
         "type": RESPONSE_CHANNEL_MESSAGE,
@@ -145,6 +155,12 @@ def handle_component_interaction(interaction: Dict[str, Any], user: Authenticate
     
     if custom_id.startswith(LOCATION_SET_PREFIX):
         return handle_location_set(interaction, user)
+    
+    if custom_id.startswith(OVERRIDE_MEAL_PREFIX):
+        return handle_override_meal(interaction, user)
+    
+    if custom_id.startswith(OVERRIDE_LOC_PREFIX):
+        return handle_override_location(interaction, user)
     
     # Placeholder for unhandled component interactions
     return {

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -109,3 +109,70 @@ def _build_override_embed(
 
     return embed
 
+# ── Button builder ───────────────────────────────────────────────────────────
+
+def _build_override_buttons(
+    actor_id: str,
+    target_user_id: str,
+    target_date: date,
+    current_state: dict,
+) -> list[Dict[str, Any]]:
+    # Meal buttons (row 1)
+    meal_buttons: list[Dict[str, Any]] = []
+    for meal_type in DEFAULT_MEAL_TYPES:
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        is_in = current_state["meals"].get(meal_type, True)
+
+        # Button will toggle to the opposite state
+        new_state = "out" if is_in else "in"
+        custom_id = (
+            f"{OVERRIDE_MEAL_PREFIX}:{actor_id}:{target_user_id}"
+            f":{target_date.isoformat()}:{meal_type.value}:{new_state}"
+        )
+
+        if is_in:
+            style = BUTTON_SUCCESS
+            label = f"{display['emoji']} {display['label']} ✅"
+        else:
+            style = BUTTON_DANGER
+            label = f"{display['emoji']} {display['label']} ❌"
+
+        meal_buttons.append({
+            "type": BUTTON,
+            "style": style,
+            "label": label,
+            "custom_id": custom_id,
+        })
+
+    # Location buttons (row 2)
+    loc_buttons: list[Dict[str, Any]] = []
+    current_loc = current_state["location"]
+    for loc_type in (WorkLocationType.OFFICE, WorkLocationType.WFH):
+        loc_display = LOCATION_DISPLAY.get(loc_type, {"label": loc_type.value, "emoji": "📍"})
+        is_active = loc_type == current_loc
+        custom_id = (
+            f"{OVERRIDE_LOC_PREFIX}:{actor_id}:{target_user_id}"
+            f":{target_date.isoformat()}:{loc_type.value}"
+        )
+
+        if is_active:
+            style = BUTTON_SUCCESS
+            label = f"{loc_display['emoji']} {loc_display['label']} ✅"
+        else:
+            style = BUTTON_SECONDARY
+            label = f"{loc_display['emoji']} {loc_display['label']}"
+
+        loc_buttons.append({
+            "type": BUTTON,
+            "style": style,
+            "label": label,
+            "custom_id": custom_id,
+            "disabled": is_active,
+        })
+
+    rows = [
+        {"type": ACTION_ROW, "components": meal_buttons},
+        {"type": ACTION_ROW, "components": loc_buttons},
+    ]
+    return rows
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import date
+from typing import Any, Dict
+
+from src.handlers.auth import AuthenticatedUser
+from src.models import MealType, WorkLocationType, UserRole
+from src.services.override_service import override_service
+from src.services.meal_service import MEAL_DISPLAY, DEFAULT_MEAL_TYPES
+from src.services.location_service import LOCATION_DISPLAY
+from src.services.discord_helpers import extract_team_from_roles
+from src.utils import parse_date_option, format_date_display, validate_date_for_update
+
+logger = logging.getLogger(__name__)
+
+# Discord response types
+RESPONSE_CHANNEL_MESSAGE = 4
+RESPONSE_UPDATE_MESSAGE = 7
+
+# Discord component types
+ACTION_ROW = 1
+BUTTON = 2
+
+# Discord button styles
+BUTTON_PRIMARY = 1    # Blurple
+BUTTON_SECONDARY = 2  # Grey
+BUTTON_SUCCESS = 3    # Green
+BUTTON_DANGER = 4     # Red
+
+# Custom ID prefixes for override buttons
+OVERRIDE_MEAL_PREFIX = "override_meal"
+OVERRIDE_LOC_PREFIX = "override_loc"
+
+# Embed color
+OVERRIDE_EMBED_COLOR = 0xED4245  # Red — distinct from self-service
+
+
+def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
+    data = interaction.get("data", {})
+    options = data.get("options", [])
+    result: dict[str, Any] = {}
+    for opt in options:
+        if opt.get("type") == 6:  # USER type
+            result[opt["name"]] = opt["value"]
+            # Also capture resolved user data if available
+            resolved = data.get("resolved", {})
+            members = resolved.get("members", {})
+            users = resolved.get("users", {})
+            if opt["value"] in users:
+                result[f"_resolved_user_{opt['name']}"] = users[opt["value"]]
+            if opt["value"] in members:
+                result[f"_resolved_member_{opt['name']}"] = members[opt["value"]]
+        else:
+            result[opt["name"]] = opt["value"]
+    return result

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -356,3 +356,91 @@ def handle_override_meal(
             },
         }
 
+# ── Location override button handler ─────────────────────────────────────────
+
+def handle_override_location(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    try:
+        data = interaction.get("data", {})
+        custom_id = data.get("custom_id", "")
+
+        parts = custom_id.split(":")
+        if len(parts) != 5 or parts[0] != OVERRIDE_LOC_PREFIX:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": "❌ Invalid button interaction.", "flags": 64},
+            }
+
+        _, actor_id, target_user_id, date_str, loc_str = parts
+
+        if user.discord_id != actor_id:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": "❌ Only the user who initiated the override can use these buttons.",
+                    "flags": 64,
+                },
+            }
+
+        target_date = date.fromisoformat(date_str)
+
+        try:
+            location = WorkLocationType(loc_str)
+        except ValueError:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ Unknown location type: {loc_str}", "flags": 64},
+            }
+
+        target_team = user.team
+
+        success, result = override_service.override_location(
+            target_user_id=target_user_id,
+            target_date=target_date,
+            location=location,
+            actor_id=user.discord_id,
+            target_team=target_team,
+        )
+
+        if not success:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ {result}", "flags": 64},
+            }
+
+        current_state = override_service.get_target_current_state(
+            target_user_id, target_date
+        )
+
+        loc_display = LOCATION_DISPLAY.get(location, {"label": location.value, "emoji": "📍"})
+        confirmation = (
+            f"✅ Updated **{loc_display['emoji']} Work Location** → "
+            f"**{loc_display['label']}** for <@{target_user_id}>"
+        )
+
+        embed = _build_override_embed(
+            target_user_id, target_user_id, target_date, current_state,
+            confirmation=confirmation,
+        )
+        components = _build_override_buttons(
+            user.discord_id, target_user_id, target_date, current_state
+        )
+
+        return {
+            "type": RESPONSE_UPDATE_MESSAGE,
+            "data": {
+                "embeds": [embed],
+                "components": components,
+            },
+        }
+
+    except Exception as e:
+        logger.exception("Error handling override location: %s", e)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": "❌ An error occurred while processing the location override. Please try again.",
+                "flags": 64,
+            },
+        }

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -52,3 +52,60 @@ def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
         else:
             result[opt["name"]] = opt["value"]
     return result
+
+# ── Embed builder ────────────────────────────────────────────────────────────
+
+def _build_override_embed(
+    target_user_id: str,
+    target_username: str,
+    target_date: date,
+    current_state: dict,
+    confirmation: str | None = None,
+) -> Dict[str, Any]:
+    # Meal fields
+    fields = []
+    for meal_type in DEFAULT_MEAL_TYPES:
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        is_in = current_state["meals"].get(meal_type, True)
+        status_emoji = "✅" if is_in else "❌"
+        status_text = "Opted In" if is_in else "Opted Out"
+        fields.append({
+            "name": f"{display['emoji']} {display['label']}",
+            "value": f"{status_emoji} {status_text}",
+            "inline": True,
+        })
+
+    # Location field
+    loc = current_state["location"]
+    loc_display = LOCATION_DISPLAY.get(loc, {"label": loc.value, "emoji": "📍"})
+    fields.append({
+        "name": f"{loc_display['emoji']} Work Location",
+        "value": f"**{loc_display['label']}**",
+        "inline": True,
+    })
+
+    description_parts = [
+        f"👤 **Employee:** <@{target_user_id}>"
+        f" ({target_username})",
+        f"📅 **Date:** {format_date_display(target_date)}",
+    ]
+
+    if confirmation:
+        description_parts.append("")
+        description_parts.append(confirmation)
+
+    description_parts.append("")
+    description_parts.append("Use the buttons below to update this employee's records.")
+
+    embed = {
+        "title": "🔧 Override Update",
+        "description": "\n".join(description_parts),
+        "fields": fields,
+        "color": OVERRIDE_EMBED_COLOR,
+        "footer": {
+            "text": "Overrides are recorded for audit purposes"
+        },
+    }
+
+    return embed
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -261,3 +261,98 @@ def handle_override_update(
             },
         }
 
+# ── Meal override button handler ─────────────────────────────────────────────
+
+def handle_override_meal(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    try:
+        data = interaction.get("data", {})
+        custom_id = data.get("custom_id", "")
+
+        parts = custom_id.split(":")
+        if len(parts) != 6 or parts[0] != OVERRIDE_MEAL_PREFIX:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": "❌ Invalid button interaction.", "flags": 64},
+            }
+
+        _, actor_id, target_user_id, date_str, meal_type_str, state_str = parts
+
+        # Security: only the original actor can click
+        if user.discord_id != actor_id:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": "❌ Only the user who initiated the override can use these buttons.",
+                    "flags": 64,
+                },
+            }
+
+        target_date = date.fromisoformat(date_str)
+
+        try:
+            meal_type = MealType(meal_type_str)
+        except ValueError:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ Unknown meal type: {meal_type_str}", "flags": 64},
+            }
+
+        is_participating = state_str == "in"
+
+        target_team = user.team  # fallback to actor's team for TL scope
+
+        success, result = override_service.override_meal(
+            target_user_id=target_user_id,
+            target_date=target_date,
+            meal_type=meal_type,
+            is_participating=is_participating,
+            actor_id=user.discord_id,
+            target_team=target_team,
+        )
+
+        if not success:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ {result}", "flags": 64},
+            }
+
+        # Refresh state and rebuild embed
+        current_state = override_service.get_target_current_state(
+            target_user_id, target_date
+        )
+
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        status_text = "✅ Opted In" if is_participating else "❌ Opted Out"
+        confirmation = (
+            f"✅ Updated **{display['emoji']} {display['label']}** → {status_text} "
+            f"for <@{target_user_id}>"
+        )
+
+        embed = _build_override_embed(
+            target_user_id, target_user_id, target_date, current_state,
+            confirmation=confirmation,
+        )
+        components = _build_override_buttons(
+            user.discord_id, target_user_id, target_date, current_state
+        )
+
+        return {
+            "type": RESPONSE_UPDATE_MESSAGE,
+            "data": {
+                "embeds": [embed],
+                "components": components,
+            },
+        }
+
+    except Exception as e:
+        logger.exception("Error handling override meal: %s", e)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": "❌ An error occurred while processing the meal override. Please try again.",
+                "flags": 64,
+            },
+        }
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -176,3 +176,88 @@ def _build_override_buttons(
     ]
     return rows
 
+# ── Command handler ──────────────────────────────────────────────────────────
+
+def handle_override_update(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    try:
+        options = _get_command_options(interaction)
+        target_user_id = options.get("employee")
+        date_str = options.get("date")
+
+        if not target_user_id:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {
+                    "content": "❌ Please select an employee to override.",
+                    "flags": 64,
+                },
+            }
+
+        try:
+            target_date = parse_date_option(date_str)
+        except ValueError as e:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ {e}", "flags": 64},
+            }
+
+        is_valid, error_msg = validate_date_for_update(target_date)
+        if not is_valid:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": f"❌ {error_msg}", "flags": 64},
+            }
+
+        target_team = None
+        resolved_member = options.get(f"_resolved_member_employee")
+        if resolved_member:
+            target_roles = resolved_member.get("roles", [])
+            target_team = extract_team_from_roles(target_roles)
+
+        # Team scope check
+        allowed, scope_err = override_service.check_team_scope(
+            actor_role=user.role,
+            actor_team=user.team,
+            target_team=target_team,
+        )
+        if not allowed:
+            return {
+                "type": RESPONSE_CHANNEL_MESSAGE,
+                "data": {"content": scope_err, "flags": 64},
+            }
+
+        current_state = override_service.get_target_current_state(
+            target_user_id, target_date
+        )
+
+        resolved_user = options.get(f"_resolved_user_employee", {})
+        target_username = resolved_user.get("username", target_user_id)
+
+        embed = _build_override_embed(
+            target_user_id, target_username, target_date, current_state
+        )
+        components = _build_override_buttons(
+            user.discord_id, target_user_id, target_date, current_state
+        )
+
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "embeds": [embed],
+                "components": components,
+                "flags": 64,
+            },
+        }
+
+    except Exception as e:
+        logger.exception("Error handling override-update: %s", e)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": "❌ An error occurred while processing the override. Please try again.",
+                "flags": 64,
+            },
+        }
+

--- a/Task2_mhp_discord-bot/backend/src/services/override_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/override_service.py
@@ -59,3 +59,41 @@ class OverrideService:
 
         # EMPLOYEE should never reach here (authorization gate catches it)
         return False, "❌ You don't have permission to use this command."
+    
+    # ── Override meal participation ───────────────────────────────────────────
+
+    def override_meal(
+        self,
+        target_user_id: str,
+        target_date: date,
+        meal_type: MealType,
+        is_participating: bool,
+        actor_id: str,
+        target_team: str | None = None,
+    ) -> tuple[bool, MealParticipation | str]:
+        # Validate date
+        is_valid, error_msg = validate_date_for_update(target_date)
+        if not is_valid:
+            return False, error_msg
+
+        now = datetime.now(DHAKA_UTC_OFFSET)
+
+        meal = MealParticipation(
+            user_id=target_user_id,
+            meal_type=meal_type,
+            date=target_date,
+            is_participating=is_participating,
+            team=target_team,
+            updated_by=actor_id,  # audit: who overrode it
+            updated_at=now,
+        )
+
+        self.storage.put_meal(meal)
+
+        status_text = "opted in" if is_participating else "opted out"
+        logger.info(
+            "Override meal: actor=%s, target=%s, date=%s, meal=%s, status=%s",
+            actor_id, target_user_id, target_date, meal_type.value, status_text,
+        )
+
+        return True, meal

--- a/Task2_mhp_discord-bot/backend/src/services/override_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/override_service.py
@@ -97,3 +97,46 @@ class OverrideService:
         )
 
         return True, meal
+    
+    # ── Override work location ───────────────────────────────────────────────
+
+    def override_location(
+        self,
+        target_user_id: str,
+        target_date: date,
+        location: WorkLocationType,
+        actor_id: str,
+        target_team: str | None = None,
+    ) -> tuple[bool, WorkLocation | str]:
+        # Validate date
+        is_valid, error_msg = validate_date_for_update(target_date)
+        if not is_valid:
+            return False, error_msg
+
+        # WFH cap check applies even for overrides
+        if location == WorkLocationType.WFH:
+            over_cap, cap_msg = self.location_svc._check_wfh_cap(
+                target_user_id, target_date
+            )
+            if over_cap:
+                return False, cap_msg
+
+        now = datetime.now(DHAKA_UTC_OFFSET)
+
+        record = WorkLocation(
+            user_id=target_user_id,
+            date=target_date,
+            location=location,
+            team=target_team,
+            updated_by=actor_id,
+            updated_at=now,
+        )
+
+        self.storage.put_location(record)
+
+        logger.info(
+            "Override location: actor=%s, target=%s, date=%s, location=%s",
+            actor_id, target_user_id, target_date, location.value,
+        )
+
+        return True, record

--- a/Task2_mhp_discord-bot/backend/src/services/override_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/override_service.py
@@ -140,3 +140,25 @@ class OverrideService:
         )
 
         return True, record
+    
+    # ── Get current states for display ───────────────────────────────────────
+
+    def get_target_current_state(
+        self, target_user_id: str, target_date: date
+    ) -> dict:
+        meals = self.meal_svc.get_user_meals_for_date(target_user_id, target_date)
+        location_record = self.location_svc.get_user_location_for_date(
+            target_user_id, target_date
+        )
+        current_location = self.location_svc.get_current_location(location_record)
+
+        meal_states = {}
+        for meal_type, record in meals.items():
+            is_in = self.meal_svc.get_participation_status(record)
+            meal_states[meal_type] = is_in
+
+        return {
+            "meals": meal_states,
+            "location": current_location,
+        }
+override_service = OverrideService()

--- a/Task2_mhp_discord-bot/backend/src/services/override_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/override_service.py
@@ -1,0 +1,61 @@
+import logging
+from datetime import date, datetime
+
+from src.config import settings
+from src.models import (
+    MealParticipation, MealType, WorkLocation, WorkLocationType, UserRole,
+)
+from src.storage.dynamodb import DynamoDBStorage, storage as default_storage
+from src.services.meal_service import meal_service as default_meal_service, MealService
+from src.services.location_service import (
+    location_service as default_location_service,
+    LocationService,
+)
+from src.utils import validate_date_for_update, DHAKA_UTC_OFFSET
+
+logger = logging.getLogger(__name__)
+
+
+class OverrideService:
+    def __init__(
+        self,
+        storage: DynamoDBStorage = None,
+        meal_svc: MealService = None,
+        location_svc: LocationService = None,
+    ):
+        self.storage = storage or default_storage
+        self.meal_svc = meal_svc or default_meal_service
+        self.location_svc = location_svc or default_location_service
+
+    # ── Team-scope check ─────────────────────────────────────────────────────
+
+    def check_team_scope(
+        self,
+        actor_role: UserRole,
+        actor_team: str | None,
+        target_team: str | None,
+    ) -> tuple[bool, str | None]:
+        if actor_role == UserRole.ADMIN:
+            return True, None
+
+        if actor_role == UserRole.TEAM_LEAD:
+            if not actor_team:
+                return False, (
+                    "❌ Your team could not be determined from your Discord roles. "
+                    "Please contact an admin."
+                )
+            if not target_team:
+                return False, (
+                    "❌ The target employee's team could not be determined. "
+                    "Please contact an admin."
+                )
+            if actor_team != target_team:
+                return False, (
+                    f"❌ You can only override employees in your team "
+                    f"(**{actor_team}**). The selected employee belongs to "
+                    f"**{target_team}**."
+                )
+            return True, None
+
+        # EMPLOYEE should never reach here (authorization gate catches it)
+        return False, "❌ You don't have permission to use this command."

--- a/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
+++ b/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
@@ -26,7 +26,7 @@ class DynamoDBStorage:
             try:
                 self._dynamodb_resource = boto3.resource(
                     "dynamodb",
-                    region_name=os.getenv("AWS_REGION", "ap-southeast-1")
+                    region_name=os.getenv("AWS_REGION", "ap-south-1")
                 )
             except Exception as e:
                 raise RuntimeError(


### PR DESCRIPTION
## Related Issues

* Closes #24

## Summary

Implements the `/override-update` slash command, allowing Team Leads and Admins to update meal participation and work location on behalf of employees. Team Leads are scoped to their own team; Admins can override any employee. All overrides are recorded with the acting user's ID for audit purposes.

## Dependencies

- Issue #23 (Work Location) — `feat/issue4/Work-Location`
- Issue #21 (Discord Auth) — `feat/issue2/discord_auth`

## Changes

### Service Layer (`src/services/override_service.py`) — **new**
- `OverrideService` class with dependency-injectable storage, meal, and location services
- `check_team_scope()` — enforces that Team Leads can only override employees within their own team; Admins bypass the check
- `override_meal()` — validates date, writes a `MealParticipation` record with `updated_by` set to the actor's Discord ID
- `override_location()` — validates date, enforces WFH monthly cap even for overrides, writes a `WorkLocation` record with audit trail
- `get_target_current_state()` — fetches the target employee's current meal and location status for embed display

### Handler Layer (`src/handlers/override_handler.py`) — **new**
- `handle_override_update()` — parses the `/override-update` slash command options (`user`, `date`), checks team scope, builds an embed showing the target's current state with interactive toggle buttons
- `handle_override_meal()` — processes meal toggle button clicks, verifies the clicking user is the original actor, calls `override_service.override_meal()`, and returns an updated embed
- `handle_override_location()` — processes location toggle button clicks with the same actor verification, calls `override_service.override_location()`, and returns an updated embed
- `_build_override_embed()` — builds a Discord embed displaying meal types and location with current status indicators
- `_build_override_buttons()` — builds interactive button rows for each meal type + location toggle
- Button security: `custom_id` encodes the actor's Discord ID; handler rejects clicks from any other user

### Auth Changes (`src/handlers/auth.py`)
- Changed `override-update` minimum role from `ADMIN` to `TEAM_LEAD` in `COMMAND_ROLE_REQUIREMENTS`

### Interaction Routing (`src/handlers/interaction.py`)
- Added imports for `override_handler` (command + component handlers + button prefixes)
- Wired `/override-update` command to `handle_override_update()`
- Wired `OVERRIDE_MEAL_PREFIX` and `OVERRIDE_LOC_PREFIX` component interactions to their respective handlers

### Config (`src/storage/dynamodb.py`)
- Changed default AWS region from `ap-southeast-1` to `ap-south-1`

## Context

Some employees may forget to update their meal status or work location. Team Leads and Admins need a way to fill in missing entries to ensure accurate headcount data. The `/override-update` command provides this corrective capability with proper team-scoping for Team Leads and full audit trails via the `updated_by` field.

## How to Test (if applicable)


## Checklist (select options which are applicable)

- [x] Code builds successfully
- [x] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes