### PR TITLE
PR 20: Refactor DynamoDB schema with user-first keys with GSI1 & GSI2 (Issues #20 & #21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode/
 plans/
+.claude/
+CLAUDE.md

--- a/Task2_mhp_discord-bot/backend/infrastructure/template.yaml
+++ b/Task2_mhp_discord-bot/backend/infrastructure/template.yaml
@@ -52,7 +52,7 @@ Globals:
 
 # Resources
 Resources:
-  # DynamoDB Table - Single Table Design (No GSIs needed)
+  # DynamoDB Table - Single Table Design with GSI1 (date-centric) and GSI2 (identity/team-centric)
   DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -66,11 +66,42 @@ Resources:
           AttributeType: S
         - AttributeName: SK
           AttributeType: S
+        - AttributeName: GSI1PK
+          AttributeType: S
+        - AttributeName: GSI1SK
+          AttributeType: S
+        - AttributeName: GSI2PK
+          AttributeType: S
+        - AttributeName: GSI2SK
+          AttributeType: S
       KeySchema:
         - AttributeName: PK
           KeyType: HASH
         - AttributeName: SK
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: GSI1
+          KeySchema:
+            - AttributeName: GSI1PK
+              KeyType: HASH
+            - AttributeName: GSI1SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 5
+            WriteCapacityUnits: 5
+        - IndexName: GSI2
+          KeySchema:
+            - AttributeName: GSI2PK
+              KeyType: HASH
+            - AttributeName: GSI2SK
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 5
+            WriteCapacityUnits: 5
       Tags:
         - Key: Environment
           Value: !Ref Environment
@@ -129,6 +160,7 @@ Resources:
                   - dynamodb:BatchWriteItem
                 Resource:
                   - !GetAtt DynamoDBTable.Arn
+                  - !Sub ${DynamoDBTable.Arn}/index/*
         - PolicyName: !Sub trainee-2026-niloy-mhp-s3-policy-${Environment}
           PolicyDocument:
             Version: '2012-10-17'
@@ -154,7 +186,7 @@ Resources:
         Api:
           Type: Api
           Properties:
-            Path: /interactions
+            Path: /discord
             Method: POST
             RestApiId: !Ref DiscordApi
 
@@ -170,7 +202,7 @@ Resources:
           title: MHP Discord Bot API
           version: "1.0"
         paths:
-          /interactions:
+          /discord:
             post:
               x-amazon-apigateway-integration:
                 uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${InteractionFunction.Arn}/invocations
@@ -184,7 +216,7 @@ Resources:
       FunctionName: !Ref InteractionFunction
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DiscordApi}/${Environment}/POST/interactions
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${DiscordApi}/${Environment}/POST/discord
 
 # Outputs
 Outputs:
@@ -202,7 +234,7 @@ Outputs:
 
   DiscordApiEndpoint:
     Description: Discord API Endpoint URL
-    Value: !Sub https://${DiscordApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/interactions
+    Value: !Sub https://${DiscordApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/discord
     Export:
       Name: !Sub ${AWS::StackName}-DiscordApiEndpoint
 

--- a/Task2_mhp_discord-bot/backend/src/models.py
+++ b/Task2_mhp_discord-bot/backend/src/models.py
@@ -2,7 +2,6 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
-import uuid
 # ── Enumerations ──────────────────────────────────────────────────────────────
 
 class UserRole(str, Enum):
@@ -32,6 +31,27 @@ class User(BaseModel):
     team: Optional[str] = None
     is_active: bool = True
     created_at: datetime = Field(default_factory=datetime.utcnow)
+    gsi2_pk: Optional[str] = None  # "USER"
+    gsi2_sk: Optional[str] = None  # "<createdAt>#<userId>"
+
+# ── External Identity ─────────────────────────────────────────────────────────
+# Enables multi-channel support (Discord, Google Chat, etc.)
+
+class ExternalIdentity(BaseModel):
+    provider: str           
+    external_id: str        
+    user_id: str            
+
+# ── Team ──────────────────────────────────────────────────────────────────────
+
+class Team(BaseModel):
+    team_id: str
+    team_name: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    # GSI2 projection fields
+    gsi2_pk: Optional[str] = None  # "TEAM"
+    gsi2_sk: Optional[str] = None  # "<teamName>#<teamId>"
+
 # ── Meal Participation ────────────────────────────────────────────────────────
 
 class MealParticipation(BaseModel):
@@ -43,6 +63,9 @@ class MealParticipation(BaseModel):
     updated_by: Optional[str] = None  # discord_id of actor
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     reason: Optional[str] = None
+    gsi1_pk: Optional[str] = None  # "DATE#<YYYY-MM-DD>"
+    gsi1_sk: Optional[str] = None  # "MEAL#<userId>#<mealType>"
+
 # ── Work Location ─────────────────────────────────────────────────────────────
 
 class WorkLocation(BaseModel):
@@ -52,12 +75,18 @@ class WorkLocation(BaseModel):
     team: Optional[str] = None  # stamped from Discord role at write time
     updated_by: Optional[str] = None
     updated_at: datetime = Field(default_factory=datetime.utcnow)
+    gsi1_pk: Optional[str] = None  # "DATE#<YYYY-MM-DD>"
+    gsi1_sk: Optional[str] = None  # "WORKLOC#<userId>"
+
 # ── Special Day ─────────────────────────────────────────────────────────────
 
 class SpecialDay(BaseModel):
     date: date
     day_type: DayType
     note: Optional[str] = None
+    gsi2_pk: Optional[str] = None  # "SPECIALDAY#<YYYY-MM>"
+    gsi2_sk: Optional[str] = None  # "DAY#<YYYY-MM-DD>"
+
 # ── Policy ─────────────────────────────────────────────────────────────────
 
 class Policy(BaseModel):

--- a/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
+++ b/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
@@ -1,16 +1,16 @@
-#DynamoDB Storage Implementation
 import os
 from datetime import date, datetime
-from typing import Optional, Any
+from typing import Optional
 
 import boto3
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Key, Attr
 from botocore.exceptions import ClientError
 
 from src.config import settings
 from src.models import (
     User, MealParticipation, WorkLocation, SpecialDay, Policy,
-    UserRole, MealType, WorkLocationType, DayType
+    UserRole, MealType, WorkLocationType, DayType,
+    ExternalIdentity, Team,
 )
 
 class DynamoDBStorage:
@@ -51,15 +51,7 @@ class DynamoDBStorage:
             item = resp.get("Item")
             if not item:
                 return None
-            return User(
-                discord_id=item["discord_id"],
-                name=item["name"],
-                email=item.get("email"),
-                role=UserRole(item.get("role", "employee")),
-                team=item.get("team"),
-                is_active=item.get("is_active", True),
-                created_at=datetime.fromisoformat(item["created_at"])
-            )
+            return _parse_user_item(item)
         except ClientError:
             return None
 
@@ -73,12 +65,105 @@ class DynamoDBStorage:
             "role": user.role.value,
             "team": user.team,
             "is_active": user.is_active,
-            "created_at": user.created_at.isoformat()
+            "created_at": user.created_at.isoformat(),
+            "GSI2PK": "USER",
+            "GSI2SK": f"{user.created_at.isoformat()}#{user.discord_id}",
         })
+        # Write external identity lookup for discord
+        self.put_identity(ExternalIdentity(
+            provider="discord",
+            external_id=user.discord_id,
+            user_id=user.discord_id,
+        ))
 
     def get_user_team(self, discord_id: str) -> Optional[str]:
         user = self.get_user(discord_id)
         return user.team if user else None
+
+    def get_user_by_identity(self, provider: str, external_id: str) -> Optional[User]:
+        try:
+            resp = self.table.get_item(
+                Key={
+                    "PK": f"IDENT#{provider}#{external_id}",
+                    "SK": f"IDENT#{provider}#{external_id}",
+                }
+            )
+            item = resp.get("Item")
+            if not item:
+                return None
+            return self.get_user(item["user_id"])
+        except ClientError:
+            return None
+
+    def get_all_users(self) -> list[User]:
+        users = []
+        try:
+            resp = self.table.query(
+                IndexName="GSI2",
+                KeyConditionExpression=Key("GSI2PK").eq("USER")
+            )
+            for item in resp.get("Items", []):
+                users.append(_parse_user_item(item))
+        except ClientError as e:
+            print(f"Error listing users: {e}")
+        return users
+
+    # ── External Identity ────────────────────────────────────────────────────
+
+    def put_identity(self, identity: ExternalIdentity) -> None:
+        self.table.put_item(Item={
+            "PK": f"IDENT#{identity.provider}#{identity.external_id}",
+            "SK": f"IDENT#{identity.provider}#{identity.external_id}",
+            "provider": identity.provider,
+            "external_id": identity.external_id,
+            "user_id": identity.user_id,
+        })
+
+    # ── Team Operations ──────────────────────────────────────────────────────
+
+    def put_team(self, team: Team) -> None:
+        self.table.put_item(Item={
+            "PK": f"TEAM#{team.team_id}",
+            "SK": "METADATA",
+            "team_id": team.team_id,
+            "team_name": team.team_name,
+            "created_at": team.created_at.isoformat(),
+            "GSI2PK": "TEAM",
+            "GSI2SK": f"{team.team_name}#{team.team_id}",
+        })
+
+    def get_team(self, team_id: str) -> Optional[Team]:
+        try:
+            resp = self.table.get_item(
+                Key={"PK": f"TEAM#{team_id}", "SK": "METADATA"}
+            )
+            item = resp.get("Item")
+            if not item:
+                return None
+            return Team(
+                team_id=item["team_id"],
+                team_name=item["team_name"],
+                created_at=datetime.fromisoformat(item["created_at"])
+            )
+        except ClientError:
+            return None
+
+    def get_all_teams(self) -> list[Team]:
+        teams = []
+        try:
+            resp = self.table.query(
+                IndexName="GSI2",
+                KeyConditionExpression=Key("GSI2PK").eq("TEAM")
+            )
+            for item in resp.get("Items", []):
+                teams.append(Team(
+                    team_id=item["team_id"],
+                    team_name=item["team_name"],
+                    created_at=datetime.fromisoformat(item["created_at"])
+                ))
+        except ClientError as e:
+            print(f"Error listing teams: {e}")
+        return teams
 
     # ── Meal Participation ───────────────────────────────────────────────────
 
@@ -86,42 +171,35 @@ class DynamoDBStorage:
         self,
         discord_id: str,
         meal_date: date,
-        meal_type: MealType
+        meal_type: MealType,
     ) -> Optional[MealParticipation]:
         try:
             resp = self.table.get_item(
                 Key={
-                    "PK": f"DATE#{meal_date.isoformat()}#MEAL",
-                    "SK": f"USER#{discord_id}#{meal_type.value}"
+                    "PK": f"USER#{discord_id}",
+                    "SK": f"MEAL#{meal_date.isoformat()}#{meal_type.value}",
                 }
             )
             item = resp.get("Item")
             if not item:
                 return None
-            return MealParticipation(
-                user_id=item["user_id"],
-                meal_type=MealType(item["meal_type"]),
-                date=date.fromisoformat(item["date"]),
-                is_participating=item.get("is_participating", True),
-                team=item.get("team"),
-                updated_by=item.get("updated_by"),
-                updated_at=datetime.fromisoformat(item["updated_at"]),
-                reason=item.get("reason")
-            )
+            return _parse_meal_item(item)
         except ClientError:
             return None
 
     def put_meal(self, meal: MealParticipation) -> None:
         item = {
-            "PK": f"DATE#{meal.date.isoformat()}#MEAL",
-            "SK": f"USER#{meal.user_id}#{meal.meal_type.value}",
+            "PK": f"USER#{meal.user_id}",
+            "SK": f"MEAL#{meal.date.isoformat()}#{meal.meal_type.value}",
             "user_id": meal.user_id,
             "date": meal.date.isoformat(),
             "meal_type": meal.meal_type.value,
             "is_participating": meal.is_participating,
             "updated_by": meal.updated_by,
             "updated_at": meal.updated_at.isoformat(),
-            "reason": meal.reason
+            "reason": meal.reason,
+            "GSI1PK": f"DATE#{meal.date.isoformat()}",
+            "GSI1SK": f"MEAL#{meal.user_id}#{meal.meal_type.value}",
         }
         if meal.team:
             item["team"] = meal.team
@@ -131,19 +209,14 @@ class DynamoDBStorage:
         meals = []
         try:
             resp = self.table.query(
-                KeyConditionExpression=Key("PK").eq(f"DATE#{meal_date.isoformat()}#MEAL")
+                IndexName="GSI1",
+                KeyConditionExpression=(
+                    Key("GSI1PK").eq(f"DATE#{meal_date.isoformat()}") &
+                    Key("GSI1SK").begins_with("MEAL#")
+                )
             )
             for item in resp.get("Items", []):
-                meals.append(MealParticipation(
-                    user_id=item["user_id"],
-                    meal_type=MealType(item["meal_type"]),
-                    date=date.fromisoformat(item["date"]),
-                    is_participating=item.get("is_participating", True),
-                    team=item.get("team"),
-                    updated_by=item.get("updated_by"),
-                    updated_at=datetime.fromisoformat(item["updated_at"]),
-                    reason=item.get("reason")
-                ))
+                meals.append(_parse_meal_item(item))
         except ClientError as e:
             print(f"Error querying meals: {e}")
         return meals
@@ -154,47 +227,32 @@ class DynamoDBStorage:
         meals = []
         try:
             resp = self.table.query(
-                KeyConditionExpression=Key("PK").eq(f"DATE#{meal_date.isoformat()}#MEAL"),
-                FilterExpression="team = :team",
-                ExpressionAttributeValues={":team": team_name}
+                IndexName="GSI1",
+                KeyConditionExpression=(
+                    Key("GSI1PK").eq(f"DATE#{meal_date.isoformat()}") &
+                    Key("GSI1SK").begins_with("MEAL#")
+                ),
+                FilterExpression=Attr("team").eq(team_name)
             )
             for item in resp.get("Items", []):
-                meals.append(MealParticipation(
-                    user_id=item["user_id"],
-                    meal_type=MealType(item["meal_type"]),
-                    date=date.fromisoformat(item["date"]),
-                    is_participating=item.get("is_participating", True),
-                    team=item.get("team"),
-                    updated_by=item.get("updated_by"),
-                    updated_at=datetime.fromisoformat(item["updated_at"]),
-                    reason=item.get("reason")
-                ))
+                meals.append(_parse_meal_item(item))
         except ClientError as e:
             print(f"Error querying team meals: {e}")
         return meals
 
-    def get_meals_for_user(self, discord_id: str, start_date: date = None) -> list[MealParticipation]:
+    def get_meals_for_user(
+        self, discord_id: str, start_date: date = None
+    ) -> list[MealParticipation]:
         meals = []
         try:
-            resp = self.table.scan(
-                FilterExpression="user_id = :uid",
-                ExpressionAttributeValues={":uid": discord_id}
-            )
+            kce = Key("PK").eq(f"USER#{discord_id}") & Key("SK").begins_with("MEAL#")
+            resp = self.table.query(KeyConditionExpression=kce)
             for item in resp.get("Items", []):
                 meal_date = date.fromisoformat(item["date"])
                 if start_date is None or meal_date >= start_date:
-                    meals.append(MealParticipation(
-                        user_id=item["user_id"],
-                        meal_type=MealType(item["meal_type"]),
-                        date=meal_date,
-                        is_participating=item.get("is_participating", True),
-                        team=item.get("team"),
-                        updated_by=item.get("updated_by"),
-                        updated_at=datetime.fromisoformat(item["updated_at"]),
-                        reason=item.get("reason")
-                    ))
+                    meals.append(_parse_meal_item(item))
         except ClientError as e:
-            print(f"Error scanning meals: {e}")
+            print(f"Error querying user meals: {e}")
         return meals
 
     # ── Work Location ───────────────────────────────────────────────────────
@@ -202,38 +260,33 @@ class DynamoDBStorage:
     def get_location(
         self,
         discord_id: str,
-        location_date: date
+        location_date: date,
     ) -> Optional[WorkLocation]:
         try:
             resp = self.table.get_item(
                 Key={
-                    "PK": f"DATE#{location_date.isoformat()}#LOCATION",
-                    "SK": f"USER#{discord_id}"
+                    "PK": f"USER#{discord_id}",
+                    "SK": f"WORKLOC#{location_date.isoformat()}",
                 }
             )
             item = resp.get("Item")
             if not item:
                 return None
-            return WorkLocation(
-                user_id=item["user_id"],
-                date=date.fromisoformat(item["date"]),
-                location=WorkLocationType(item["location"]),
-                team=item.get("team"),
-                updated_by=item.get("updated_by"),
-                updated_at=datetime.fromisoformat(item["updated_at"])
-            )
+            return _parse_location_item(item)
         except ClientError:
             return None
 
     def put_location(self, location: WorkLocation) -> None:
         item = {
-            "PK": f"DATE#{location.date.isoformat()}#LOCATION",
-            "SK": f"USER#{location.user_id}",
+            "PK": f"USER#{location.user_id}",
+            "SK": f"WORKLOC#{location.date.isoformat()}",
             "user_id": location.user_id,
             "date": location.date.isoformat(),
             "location": location.location.value,
             "updated_by": location.updated_by,
-            "updated_at": location.updated_at.isoformat()
+            "updated_at": location.updated_at.isoformat(),
+            "GSI1PK": f"DATE#{location.date.isoformat()}",
+            "GSI1SK": f"WORKLOC#{location.user_id}",
         }
         if location.team:
             item["team"] = location.team
@@ -243,17 +296,14 @@ class DynamoDBStorage:
         locations = []
         try:
             resp = self.table.query(
-                KeyConditionExpression=Key("PK").eq(f"DATE#{location_date.isoformat()}#LOCATION")
+                IndexName="GSI1",
+                KeyConditionExpression=(
+                    Key("GSI1PK").eq(f"DATE#{location_date.isoformat()}") &
+                    Key("GSI1SK").begins_with("WORKLOC#")
+                )
             )
             for item in resp.get("Items", []):
-                locations.append(WorkLocation(
-                    user_id=item["user_id"],
-                    date=date.fromisoformat(item["date"]),
-                    location=WorkLocationType(item["location"]),
-                    team=item.get("team"),
-                    updated_by=item.get("updated_by"),
-                    updated_at=datetime.fromisoformat(item["updated_at"])
-                ))
+                locations.append(_parse_location_item(item))
         except ClientError as e:
             print(f"Error querying locations: {e}")
         return locations
@@ -264,23 +314,37 @@ class DynamoDBStorage:
         locations = []
         try:
             resp = self.table.query(
-                KeyConditionExpression=Key("PK").eq(
-                    f"DATE#{location_date.isoformat()}#LOCATION"
+                IndexName="GSI1",
+                KeyConditionExpression=(
+                    Key("GSI1PK").eq(f"DATE#{location_date.isoformat()}") &
+                    Key("GSI1SK").begins_with("WORKLOC#")
                 ),
-                FilterExpression="team = :team",
-                ExpressionAttributeValues={":team": team_name}
+                FilterExpression=Attr("team").eq(team_name)
             )
             for item in resp.get("Items", []):
-                locations.append(WorkLocation(
-                    user_id=item["user_id"],
-                    date=date.fromisoformat(item["date"]),
-                    location=WorkLocationType(item["location"]),
-                    team=item.get("team"),
-                    updated_by=item.get("updated_by"),
-                    updated_at=datetime.fromisoformat(item["updated_at"])
-                ))
+                locations.append(_parse_location_item(item))
         except ClientError as e:
             print(f"Error querying team locations: {e}")
+        return locations
+
+    def get_locations_for_date_range(
+        self, discord_id: str, start_date: date, end_date: date
+    ) -> list[WorkLocation]:
+        locations = []
+        try:
+            resp = self.table.query(
+                KeyConditionExpression=(
+                    Key("PK").eq(f"USER#{discord_id}") &
+                    Key("SK").between(
+                        f"WORKLOC#{start_date.isoformat()}",
+                        f"WORKLOC#{end_date.isoformat()}",
+                    )
+                )
+            )
+            for item in resp.get("Items", []):
+                locations.append(_parse_location_item(item))
+        except ClientError as e:
+            print(f"Error querying location range: {e}")
         return locations
 
     # ── Special Day ─────────────────────────────────────────────────────────
@@ -288,7 +352,7 @@ class DynamoDBStorage:
     def get_special_day(self, special_date: date) -> Optional[SpecialDay]:
         try:
             resp = self.table.get_item(
-                Key={"PK": f"SPECIALDAY#{special_date.isoformat()}", "SK": "-"}
+                Key={"PK": f"DAY#{special_date.isoformat()}", "SK": "METADATA"}
             )
             item = resp.get("Item")
             if not item:
@@ -302,13 +366,33 @@ class DynamoDBStorage:
             return None
 
     def put_special_day(self, special_day: SpecialDay) -> None:
+        year_month = special_day.date.strftime("%Y-%m")
         self.table.put_item(Item={
-            "PK": f"SPECIALDAY#{special_day.date.isoformat()}",
-            "SK": "-",
+            "PK": f"DAY#{special_day.date.isoformat()}",
+            "SK": "METADATA",
             "date": special_day.date.isoformat(),
             "day_type": special_day.day_type.value,
-            "note": special_day.note
+            "note": special_day.note,
+            "GSI2PK": f"SPECIALDAY#{year_month}",
+            "GSI2SK": f"DAY#{special_day.date.isoformat()}",
         })
+
+    def get_special_days_for_month(self, year_month: str) -> list[SpecialDay]:
+        special_days = []
+        try:
+            resp = self.table.query(
+                IndexName="GSI2",
+                KeyConditionExpression=Key("GSI2PK").eq(f"SPECIALDAY#{year_month}")
+            )
+            for item in resp.get("Items", []):
+                special_days.append(SpecialDay(
+                    date=date.fromisoformat(item["date"]),
+                    day_type=DayType(item["day_type"]),
+                    note=item.get("note")
+                ))
+        except ClientError as e:
+            print(f"Error querying special days: {e}")
+        return special_days
 
     # ── Policy ───────────────────────────────────────────────────────────────
 
@@ -336,5 +420,40 @@ class DynamoDBStorage:
             "value": policy.value,
             "updated_at": policy.updated_at.isoformat()
         })
+
+# ── Private helpers ──────────────────────────────────────────────────────────
+
+def _parse_user_item(item: dict) -> User:
+    return User(
+        discord_id=item["discord_id"],
+        name=item["name"],
+        email=item.get("email"),
+        role=UserRole(item.get("role", "employee")),
+        team=item.get("team"),
+        is_active=item.get("is_active", True),
+        created_at=datetime.fromisoformat(item["created_at"])
+    )
+
+def _parse_meal_item(item: dict) -> MealParticipation:
+    return MealParticipation(
+        user_id=item["user_id"],
+        meal_type=MealType(item["meal_type"]),
+        date=date.fromisoformat(item["date"]),
+        is_participating=item.get("is_participating", True),
+        team=item.get("team"),
+        updated_by=item.get("updated_by"),
+        updated_at=datetime.fromisoformat(item["updated_at"]),
+        reason=item.get("reason")
+    )
+
+def _parse_location_item(item: dict) -> WorkLocation:
+    return WorkLocation(
+        user_id=item["user_id"],
+        date=date.fromisoformat(item["date"]),
+        location=WorkLocationType(item["location"]),
+        team=item.get("team"),
+        updated_by=item.get("updated_by"),
+        updated_at=datetime.fromisoformat(item["updated_at"])
+    )
 # Singleton instance
 storage = DynamoDBStorage()

--- a/Task2_mhp_discord-bot/task-iteration2.md
+++ b/Task2_mhp_discord-bot/task-iteration2.md
@@ -1,0 +1,23 @@
+## Iteration 2 (Week 2) — DynamoDB + Scheduled Summaries + Docker + CI/CD (BE4 + DO1 + DO2 + BE3)
+### Feature requests
+1. **DynamoDB persistence**
+   - Persist participation entries, work-location entries, special days, and company-wide WFH periods.
+   - Reports and dashboards read from persisted data.
+
+2. **Report-ready retrieval**
+   - Admin can retrieve daily totals quickly for a selected date.
+   - Team Leads can retrieve team-level participation quickly for a selected date.
+   - Monthly WFH usage summary is available (soft limit: accept beyond 5, but flag/report it).
+
+3. **Scheduled daily post to Discord**
+   - System posts a daily summary message to a configured Discord channel at a configured time.
+   - The post includes meal totals and special-day context (holiday/office closed/celebration).
+
+4. **Containerized delivery**
+   - System runs via containers (web + backend + bot).
+   - A single “run locally” workflow exists for developers.
+
+5. **CI/CD pipeline** (deferred to later and not done yet)
+   - On pull requests: run checks and build artifacts.
+   - On merge to main: publish release artifacts (and optionally deploy to a shared internal environment).
+   - Build version is visible in the web UI and included in bot responses (basic release visibility).


### PR DESCRIPTION
## Related Issues
* Fixes #49
* Fixes #50

## Summary
Redesigns the DynamoDB single-table schema from date-first to user-first primary keys and introduces two Global Secondary Indexes (GSI1 for date-centric headcount queries, GSI2 for identity/team listing), replacing all full-table scans with targeted queries.

## Dependencies
- docs/issue20_21/DynamoDB_redesign (documentation PR)

## Changes
- `infrastructure/template.yaml` — Added GSI1 and GSI2 attribute definitions and index configurations; updated Lambda IAM policy to include `index/*` ARN for GSI query permissions
- `src/models.py` — Added `ExternalIdentity` and `Team` models; added optional GSI projection fields (`gsi1_pk`, `gsi1_sk`, `gsi2_pk`, `gsi2_sk`) to `MealParticipation`, `WorkLocation`, `User`, and `SpecialDay`
- `src/storage/dynamodb.py` — Complete storage layer rewrite: user-first key schema throughout, new methods (`get_user_by_identity`, `get_all_users`, `put_identity`, `put_team`, `get_team`, `get_all_teams`, `get_special_days_for_month`), implemented previously missing `get_locations_for_date_range`, all date-based headcount queries now use GSI1

## Context
The old schema used date-first partition keys (`PK=DATE#<date>#MEAL`) which made daily headcount efficient but required full table scans for user-history queries (meal history, monthly WFH count). The new schema uses user-first keys (`PK=USER#<userId>`) with:
- **GSI1** (`GSI1PK=DATE#<date>`) for daily headcount — replaces date-first PK scans
- **GSI2** (`GSI2PK=USER|TEAM|SPECIALDAY#<YYYY-MM>`) for listing users, teams, and monthly special days
- **Provider-neutral identity** (`IDENT#<provider>#<externalId>`) for future multi-channel support (Google Chat, etc.)

## How to Test
* [AWS DynamoDB Table Link](https://ap-south-1.console.aws.amazon.com/dynamodbv2/home?region=ap-south-1#table?name=trainee-2026-niloy-mhp-data&tab=overview)
1. In the AWS Console → DynamoDB, confirm the table `trainee-2026-niloy-mhp-data` has two active indexes: **GSI1** and **GSI2**
2. In the DynamoDB Console, query GSI1 with `GSI1PK = DATE#<today>` — confirm meal/location records are returned

## Checklist
- [x] Code builds successfully
- [x] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes