### PR TITLE
PR 21: Document multi-lambda architecture changes for Issue #2.19

### DIFF
--- a/Task2_mhp_discord-bot/docs/technical-documentation.md
+++ b/Task2_mhp_discord-bot/docs/technical-documentation.md
@@ -1,9 +1,9 @@
 # MHP Discord Bot — Technical Documentation
 
-> **Version:** 1.5.0
+> **Version:** 1.6.0
 > **Last Updated:** 2026-03-18
-> **Status:** Issues #20 & #21 Complete — DynamoDB Schema Redesign (User-first + GSIs)
-> **Addressed Issues:** #1, #2, #3, #4, #5, #20, #21
+> **Status:** Issue #19 Complete — Multi-Lambda Architecture
+> **Addressed Issues (Prefix 2.x):** #1, #2, #3, #4, #5, #19, #20, #21
 
 ---
 
@@ -57,13 +57,22 @@ This document covers the technical implementation of the Meal Headcount Planner 
 ### High-Level Flow
 
 ```
-User → Discord → API Gateway → Lambda → DynamoDB/S3
-                ↓
-         PyNaCl Signature
-         Verification
-         ↓
-    Role-based Access
-    Control (RBAC)
+User → Discord → API Gateway → IngressFunction (ingress.py)
+                                    │
+                                    ├── PyNaCl Signature Verification
+                                    ├── Auth + Role-based Access Control
+                                    ├── PING → PONG (direct)
+                                    │
+                                    ├── ENABLE_MULTI_LAMBDA=false (default)
+                                    │     └── In-process routing → handler modules
+                                    │
+                                    └── ENABLE_MULTI_LAMBDA=true
+                                          ├── Slash command → deferred (type 5)
+                                          │     + async invoke → MealFunction /
+                                          │       LocationFunction / OverrideFunction
+                                          │         └── posts follow-up via Discord webhook
+                                          └── Component → sync invoke → feature Lambda
+                                                  └── result returned to Discord
 ```
 
 ---
@@ -74,13 +83,18 @@ User → Discord → API Gateway → Lambda → DynamoDB/S3
 
 All infrastructure is defined in [`infrastructure/template.yaml`](infrastructure/template.yaml) using AWS SAM.
 
-#### Lambda Function
+#### Lambda Functions (Issue #19 — Multi-Lambda Architecture)
 
-- **Function Name:** `mhp-interaction-{environment}`
-- **Runtime:** Python 3.12
-- **Timeout:** 30 seconds
-- **Memory:** 256 MB
-- **Handler:** `src.handlers.interaction.lambda_handler`
+| Function | Name | Handler | IAM Scope |
+|----------|------|---------|-----------|
+| Ingress | `trainee-2026-niloy-mhp-ingress-{env}` | `src.handlers.ingress.lambda_handler` | Lambda invoke only |
+| Meal | `trainee-2026-niloy-mhp-meal-{env}` | `src.handlers.meal_handler.lambda_handler` | DynamoDB + S3 |
+| Location | `trainee-2026-niloy-mhp-location-{env}` | `src.handlers.location_handler.lambda_handler` | DynamoDB + S3 |
+| Override | `trainee-2026-niloy-mhp-override-{env}` | `src.handlers.override_handler.lambda_handler` | DynamoDB + S3 |
+
+- **Runtime:** Python 3.12, **Timeout:** 30 s, **Memory:** 256 MB (all functions)
+- **Dispatch:** Controlled by `ENABLE_MULTI_LAMBDA` env var (default `false` — in-process fallback active)
+- **Legacy entry point:** `src.handlers.interaction.lambda_handler` retained for reference; not deployed
 
 #### API Gateway
 
@@ -137,6 +151,10 @@ All infrastructure is defined in [`infrastructure/template.yaml`](infrastructure
 | `FORWARD_PLANNING_DAYS` | Max days ahead to book | `7` |
 | `TIMEZONE` | timezone | `Asia/Dhaka` |
 | `DEBUG` | Enable debug mode | `false` |
+| `ENABLE_MULTI_LAMBDA` | Route commands to feature Lambdas | `false` |
+| `MEAL_FUNCTION_NAME` | ARN/name of MealFunction | (set by SAM) |
+| `LOCATION_FUNCTION_NAME` | ARN/name of LocationFunction | (set by SAM) |
+| `OVERRIDE_FUNCTION_NAME` | ARN/name of OverrideFunction | (set by SAM) |
 
 #### Role Mapping Config
 


### PR DESCRIPTION
## Related Issues
* Fixes #48

## Summary
Updates technical documentation to reflect the multi-Lambda architecture introduced in Issue #48: ingress function, three feature functions, feature-flag-gated dispatch, and deferred response pattern.

## Dependencies
_(none)_

## Changes
* Version header: bumped 1.5.0 → 1.6.0, status updated to "Issue 19 Complete — Multi-Lambda Architecture", #48 added to Addressed Issues
* Architecture → High-Level Flow: replaced single-Lambda diagram with annotated multi-Lambda flow showing ingress verification path, ENABLE_MULTI_LAMBDA flag branches, async slash command dispatch + Discord webhook follow-up, and sync component dispatch
* Infrastructure → Lambda Functions: replaced single function entry with a 4-row table (Ingress, Meal, Location, Override) documenting function names, handlers, and IAM scope per function; added dispatch behavior note and legacy interaction.py retention note
* Infrastructure → Application Config table: added ENABLE_MULTI_LAMBDA, MEAL_FUNCTION_NAME, LOCATION_FUNCTION_NAME, OVERRIDE_FUNCTION_NAME env vars

## Context
Issue #48 split the monolithic Lambda into a front-door IngressFunction (signature verification + auth + dispatch) and three dedicated feature Lambdas (Meal, Location, Override). A ENABLE_MULTI_LAMBDA feature flag defaults to false for zero-behavior-change rollout — the existing in-process routing path remains active until the flag is flipped. Slash commands use async dispatch (type 5 deferred + Discord webhook follow-up) to avoid Discord's 3-second timeout; component interactions (button clicks) use synchronous dispatch since they are fast DynamoDB operations that need immediate UI feedback.

## How to Test (if applicable)
N/A — documentation only

## Checklist
 * [x] Documentation updated/added
 * [x] No breaking changes