### PR TITLE
PR 22: Refactor Multi lambda approach for Issue #2.19

### DIFF
--- a/Task2_mhp_discord-bot/backend/src/config.py
+++ b/Task2_mhp_discord-bot/backend/src/config.py
@@ -37,6 +37,12 @@ class Settings(BaseModel):
     # Debug mode
     DEBUG: bool = False
 
+    # Multi-Lambda dispatch
+    ENABLE_MULTI_LAMBDA: bool = False
+    MEAL_FUNCTION_NAME: str = ""
+    LOCATION_FUNCTION_NAME: str = ""
+    OVERRIDE_FUNCTION_NAME: str = ""
+
 @lru_cache()
 def get_settings() -> Settings:
     return Settings(
@@ -60,5 +66,9 @@ def get_settings() -> Settings:
         FORWARD_PLANNING_DAYS=int(os.getenv("FORWARD_PLANNING_DAYS", "7")),
         TIMEZONE=os.getenv("TIMEZONE", "Asia/Dhaka"),
         DEBUG=os.getenv("DEBUG", "false").lower() == "true",
+        ENABLE_MULTI_LAMBDA=os.getenv("ENABLE_MULTI_LAMBDA", "false").lower() == "true",
+        MEAL_FUNCTION_NAME=os.getenv("MEAL_FUNCTION_NAME", ""),
+        LOCATION_FUNCTION_NAME=os.getenv("LOCATION_FUNCTION_NAME", ""),
+        OVERRIDE_FUNCTION_NAME=os.getenv("OVERRIDE_FUNCTION_NAME", ""),
     )
 settings = get_settings()

--- a/Task2_mhp_discord-bot/backend/src/handlers/dispatcher.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/dispatcher.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+# ── Command → Lambda function name ───────────────────────────────────────────
+COMMAND_FUNCTION_MAP: Dict[str, str] = {
+    "meal-update":     os.getenv("MEAL_FUNCTION_NAME", ""),
+    "work-location":   os.getenv("LOCATION_FUNCTION_NAME", ""),
+    "override-update": os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+}
+
+# ── Component custom_id prefix → Lambda function name ────────────────────────
+COMPONENT_PREFIX_MAP: Dict[str, str] = {
+    "meal_toggle":   os.getenv("MEAL_FUNCTION_NAME", ""),
+    "location_set":  os.getenv("LOCATION_FUNCTION_NAME", ""),
+    "override_meal": os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+    "override_loc":  os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+}
+
+def get_function_for_command(command_name: str) -> Optional[str]:
+    fn = COMMAND_FUNCTION_MAP.get(command_name)
+    return fn if fn else None
+
+def get_function_for_component(custom_id: str) -> Optional[str]:
+    for prefix, fn in COMPONENT_PREFIX_MAP.items():
+        if custom_id.startswith(prefix):
+            return fn if fn else None
+    return None
+
+def dispatch(
+    function_name: str,
+    payload: Dict[str, Any],
+    async_mode: bool = False,
+) -> Optional[Dict[str, Any]]:
+    client = boto3.client("lambda")
+    invocation_type = "Event" if async_mode else "RequestResponse"
+
+    logger.info(
+        "Dispatching to %s (invocation_type=%s)", function_name, invocation_type
+    )
+
+    resp = client.invoke(
+        FunctionName=function_name,
+        InvocationType=invocation_type,
+        Payload=json.dumps(payload).encode(),
+    )
+
+    if async_mode:
+        return None
+
+    raw = resp["Payload"].read()
+    if not raw:
+        return None
+    return json.loads(raw)

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -1,0 +1,117 @@
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from nacl.signing import VerifyKey
+from nacl.encoding import RawEncoder
+
+from src.config import settings
+from src.handlers.auth import (
+    AuthenticatedUser,
+    get_user_from_interaction as auth_get_user,
+    check_command_authorization,
+)
+from src.handlers.meal_handler import (
+    handle_meal_update,
+    handle_meal_toggle,
+    MEAL_TOGGLE_PREFIX,
+)
+from src.handlers.location_handler import (
+    handle_work_location,
+    handle_location_set,
+    LOCATION_SET_PREFIX,
+)
+from src.handlers.override_handler import (
+    handle_override_update,
+    handle_override_meal,
+    handle_override_location,
+    OVERRIDE_MEAL_PREFIX,
+    OVERRIDE_LOC_PREFIX,
+)
+from src.handlers import dispatcher
+from src.models import UserRole
+
+logger = logging.getLogger(__name__)
+
+# Discord interaction types
+INTERACTION_PING = 1
+INTERACTION_APPLICATION_COMMAND = 2
+INTERACTION_MESSAGE_COMPONENT = 3
+
+# Discord response types
+RESPONSE_PONG = 1
+RESPONSE_CHANNEL_MESSAGE = 4
+RESPONSE_DEFERRED_CHANNEL_MESSAGE = 5
+RESPONSE_DEFERRED_UPDATE_MESSAGE = 6
+RESPONSE_UPDATE_MESSAGE = 7
+
+# ── Signature verification ────────────────────────────────────────────────────
+
+def verify_signature(event_body: str, signature: str, timestamp: str) -> bool:
+    try:
+        public_key = settings.DISCORD_PUBLIC_KEY
+        if not public_key:
+            logger.error("DISCORD_PUBLIC_KEY not configured")
+            return False
+        verify_key = VerifyKey(bytes.fromhex(public_key))
+        message = timestamp.encode() + event_body.encode()
+        verify_key.verify(message, bytes.fromhex(signature), encoder=RawEncoder)
+        return True
+    except Exception as e:
+        logger.error(f"Signature verification failed: {e}")
+        return False
+
+
+def parse_interaction(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    headers = event.get("headers", {}) or {}
+    signature = headers.get("X-Signature-Ed25519") or headers.get("x-signature-ed25519")
+    timestamp = headers.get("X-Signature-Timestamp") or headers.get("x-signature-timestamp")
+    body = event.get("body", "")
+
+    if settings.DEBUG and os.getenv("SKIP_SIGNATURE_VERIFICATION"):
+        logger.warning("Signature verification skipped (DEBUG mode)")
+    elif not signature or not timestamp:
+        logger.error("Missing signature or timestamp headers")
+        return None
+    elif not verify_signature(body, signature, timestamp):
+        logger.error("Invalid signature")
+        return None
+
+    try:
+        if event.get("isBase64Encoded"):
+            import base64
+            body = base64.b64decode(body).decode("utf-8")
+        return json.loads(body)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse JSON: {e}")
+        return None
+
+
+def get_command_name(interaction: Dict[str, Any]) -> str:
+    return interaction.get("data", {}).get("name", "")
+
+
+def create_error_response(message: str) -> Dict[str, Any]:
+    return {
+        "type": RESPONSE_CHANNEL_MESSAGE,
+        "data": {"content": f"❌ {message}", "flags": 64},
+    }
+
+
+def _deferred_response() -> Dict[str, Any]:
+    return {"type": RESPONSE_DEFERRED_CHANNEL_MESSAGE}
+
+
+def _serialize_user(user: AuthenticatedUser) -> Dict[str, Any]:
+    return {
+        "discord_id": user.discord_id,
+        "username": user.username,
+        "global_name": user.global_name,
+        "role": user.role.value,
+        "team": user.team,
+        "guild_id": user.guild_id,
+        "discord_roles": user.discord_roles,
+    }
+
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -114,4 +114,46 @@ def _serialize_user(user: AuthenticatedUser) -> Dict[str, Any]:
         "discord_roles": user.discord_roles,
     }
 
+# ── In-process routing (fallback path) ───────────────────────────────────────
+
+def _route_command_inprocess(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    command_name = get_command_name(interaction)
+    logger.info(f"In-process routing command: {command_name}")
+
+    if command_name == "meal-update":
+        return handle_meal_update(interaction, user)
+    if command_name == "work-location":
+        return handle_work_location(interaction, user)
+    if command_name == "override-update":
+        return handle_override_update(interaction, user)
+
+    return {
+        "type": RESPONSE_CHANNEL_MESSAGE,
+        "data": {
+            "content": f"🔧 Command `{command_name}` is being implemented. Stay tuned!\n\nYour role: {user.role.value}",
+            "flags": 64,
+        },
+    }
+
+
+def _route_component_inprocess(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    custom_id = interaction.get("data", {}).get("custom_id", "")
+
+    if custom_id.startswith(MEAL_TOGGLE_PREFIX):
+        return handle_meal_toggle(interaction, user)
+    if custom_id.startswith(LOCATION_SET_PREFIX):
+        return handle_location_set(interaction, user)
+    if custom_id.startswith(OVERRIDE_MEAL_PREFIX):
+        return handle_override_meal(interaction, user)
+    if custom_id.startswith(OVERRIDE_LOC_PREFIX):
+        return handle_override_location(interaction, user)
+
+    return {
+        "type": RESPONSE_CHANNEL_MESSAGE,
+        "data": {"content": "🔧 Component interactions are being implemented.", "flags": 64},
+    }
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -157,3 +157,44 @@ def _route_component_inprocess(
         "data": {"content": "🔧 Component interactions are being implemented.", "flags": 64},
     }
 
+# ── Multi-Lambda dispatch path ────────────────────────────────────────────────
+
+def _dispatch_command(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    command_name = get_command_name(interaction)
+    fn = dispatcher.get_function_for_command(command_name)
+
+    if not fn:
+        logger.warning(f"No feature Lambda configured for command: {command_name}")
+        return _route_command_inprocess(interaction, user)
+
+    payload = {
+        "dispatch_type": "command",
+        "interaction": interaction,
+        "user": _serialize_user(user),
+    }
+    dispatcher.dispatch(fn, payload, async_mode=True)
+    return _deferred_response()
+
+
+def _dispatch_component(
+    interaction: Dict[str, Any], user: AuthenticatedUser
+) -> Dict[str, Any]:
+    custom_id = interaction.get("data", {}).get("custom_id", "")
+    fn = dispatcher.get_function_for_component(custom_id)
+
+    if not fn:
+        logger.warning(f"No feature Lambda configured for component: {custom_id}")
+        return _route_component_inprocess(interaction, user)
+
+    payload = {
+        "dispatch_type": "component",
+        "interaction": interaction,
+        "user": _serialize_user(user),
+    }
+    result = dispatcher.dispatch(fn, payload, async_mode=False)
+    if result is None:
+        return create_error_response("Feature Lambda returned no response.")
+    return result
+

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -100,7 +100,7 @@ def create_error_response(message: str) -> Dict[str, Any]:
 
 
 def _deferred_response() -> Dict[str, Any]:
-    return {"type": RESPONSE_DEFERRED_CHANNEL_MESSAGE}
+    return {"type": RESPONSE_DEFERRED_CHANNEL_MESSAGE, "data": {"flags": 64}}
 
 
 def _serialize_user(user: AuthenticatedUser) -> Dict[str, Any]:
@@ -174,8 +174,10 @@ def _dispatch_command(
         "interaction": interaction,
         "user": _serialize_user(user),
     }
-    dispatcher.dispatch(fn, payload, async_mode=True)
-    return _deferred_response()
+    result = dispatcher.dispatch(fn, payload, async_mode=False)
+    if result is None:
+        return create_error_response("Feature Lambda returned no response.")
+    return result
 
 
 def _dispatch_component(

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -198,3 +198,72 @@ def _dispatch_component(
         return create_error_response("Feature Lambda returned no response.")
     return result
 
+# ── Lambda entry point ────────────────────────────────────────────────────────
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    logger.info(f"Received event: {event.get('httpMethod')} {event.get('path')}")
+
+    try:
+        interaction = parse_interaction(event)
+        if not interaction:
+            return {
+                "statusCode": 401,
+                "body": json.dumps({"error": "Invalid signature"}),
+            }
+
+        interaction_type = interaction.get("type")
+
+        if interaction_type == INTERACTION_PING:
+            logger.info("Responding to PING")
+            return {
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps({"type": RESPONSE_PONG}),
+            }
+
+        user = auth_get_user(interaction)
+        logger.info(
+            f"User authenticated: {user.username} ({user.discord_id}), role: {user.role.value}"
+        )
+
+        # Authorization check (applies to both routing paths)
+        command_name = get_command_name(interaction) if interaction_type == INTERACTION_APPLICATION_COMMAND else ""
+        if command_name:
+            is_authorized, error_msg = check_command_authorization(command_name, user)
+            if not is_authorized:
+                response = create_error_response(error_msg)
+                return {
+                    "statusCode": 200,
+                    "headers": {"Content-Type": "application/json"},
+                    "body": json.dumps(response),
+                }
+
+        if settings.ENABLE_MULTI_LAMBDA:
+            if interaction_type == INTERACTION_APPLICATION_COMMAND:
+                response = _dispatch_command(interaction, user)
+            elif interaction_type == INTERACTION_MESSAGE_COMPONENT:
+                response = _dispatch_component(interaction, user)
+            else:
+                response = create_error_response(f"Unknown interaction type: {interaction_type}")
+        else:
+            # Fallback: in-process routing (same as original interaction.py)
+            if interaction_type == INTERACTION_APPLICATION_COMMAND:
+                response = _route_command_inprocess(interaction, user)
+            elif interaction_type == INTERACTION_MESSAGE_COMPONENT:
+                response = _route_component_inprocess(interaction, user)
+            else:
+                response = create_error_response(f"Unknown interaction type: {interaction_type}")
+
+        return {
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(response),
+        }
+
+    except Exception as e:
+        logger.exception(f"Error handling interaction: {e}")
+        return {
+            "statusCode": 500,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps(create_error_response("An error occurred processing your request")),
+        }

--- a/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
@@ -4,7 +4,9 @@ from datetime import date
 from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
-from src.models import WorkLocationType
+from src.models import WorkLocationType, UserRole
+from src.config import settings
+from src.services.discord_follow_up import post_follow_up
 from src.services.location_service import location_service, LOCATION_DISPLAY
 from src.utils import parse_date_option, format_date_display, validate_date_for_update
 
@@ -239,3 +241,32 @@ def handle_location_set(
                 "flags": 64,
             },
         }
+
+
+# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    interaction = event["interaction"]
+    user_dict = event["user"]
+    dispatch_type = event["dispatch_type"]
+
+    user = AuthenticatedUser(
+        discord_id=user_dict["discord_id"],
+        username=user_dict["username"],
+        global_name=user_dict.get("global_name"),
+        role=UserRole(user_dict["role"]),
+        team=user_dict.get("team"),
+        guild_id=user_dict["guild_id"],
+        discord_roles=user_dict.get("discord_roles", []),
+    )
+
+    if dispatch_type == "command":
+        response = handle_work_location(interaction, user)
+        post_follow_up(
+            settings.DISCORD_APPLICATION_ID,
+            interaction["token"],
+            response["data"],
+        )
+        return {"statusCode": 200}
+    else:
+        return handle_location_set(interaction, user)

--- a/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
@@ -5,8 +5,6 @@ from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
 from src.models import WorkLocationType, UserRole
-from src.config import settings
-from src.services.discord_follow_up import post_follow_up
 from src.services.location_service import location_service, LOCATION_DISPLAY
 from src.utils import parse_date_option, format_date_display, validate_date_for_update
 
@@ -261,12 +259,6 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     )
 
     if dispatch_type == "command":
-        response = handle_work_location(interaction, user)
-        post_follow_up(
-            settings.DISCORD_APPLICATION_ID,
-            interaction["token"],
-            response["data"],
-        )
-        return {"statusCode": 200}
+        return handle_work_location(interaction, user)
     else:
         return handle_location_set(interaction, user)

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -5,8 +5,6 @@ from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
 from src.models import MealType, UserRole
-from src.config import settings
-from src.services.discord_follow_up import post_follow_up
 from src.services.meal_service import meal_service, MEAL_DISPLAY
 from src.utils import parse_date_option, format_date_display, validate_date_for_update
 
@@ -259,12 +257,6 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     )
 
     if dispatch_type == "command":
-        response = handle_meal_update(interaction, user)
-        post_follow_up(
-            settings.DISCORD_APPLICATION_ID,
-            interaction["token"],
-            response["data"],
-        )
-        return {"statusCode": 200}
+        return handle_meal_update(interaction, user)
     else:
         return handle_meal_toggle(interaction, user)

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -4,7 +4,9 @@ from datetime import date
 from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
-from src.models import MealType
+from src.models import MealType, UserRole
+from src.config import settings
+from src.services.discord_follow_up import post_follow_up
 from src.services.meal_service import meal_service, MEAL_DISPLAY
 from src.utils import parse_date_option, format_date_display, validate_date_for_update
 
@@ -237,3 +239,32 @@ def handle_meal_toggle(
                 "flags": 64,
             },
         }
+
+
+# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    interaction = event["interaction"]
+    user_dict = event["user"]
+    dispatch_type = event["dispatch_type"]
+
+    user = AuthenticatedUser(
+        discord_id=user_dict["discord_id"],
+        username=user_dict["username"],
+        global_name=user_dict.get("global_name"),
+        role=UserRole(user_dict["role"]),
+        team=user_dict.get("team"),
+        guild_id=user_dict["guild_id"],
+        discord_roles=user_dict.get("discord_roles", []),
+    )
+
+    if dispatch_type == "command":
+        response = handle_meal_update(interaction, user)
+        post_follow_up(
+            settings.DISCORD_APPLICATION_ID,
+            interaction["token"],
+            response["data"],
+        )
+        return {"statusCode": 200}
+    else:
+        return handle_meal_toggle(interaction, user)

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -4,6 +4,8 @@ from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
 from src.models import MealType, WorkLocationType, UserRole
+from src.config import settings
+from src.services.discord_follow_up import post_follow_up
 from src.services.override_service import override_service
 from src.services.meal_service import MEAL_DISPLAY, DEFAULT_MEAL_TYPES
 from src.services.location_service import LOCATION_DISPLAY
@@ -443,4 +445,42 @@ def handle_override_location(
                 "content": "❌ An error occurred while processing the location override. Please try again.",
                 "flags": 64,
             },
+        }
+
+
+# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    interaction = event["interaction"]
+    user_dict = event["user"]
+    dispatch_type = event["dispatch_type"]
+
+    user = AuthenticatedUser(
+        discord_id=user_dict["discord_id"],
+        username=user_dict["username"],
+        global_name=user_dict.get("global_name"),
+        role=UserRole(user_dict["role"]),
+        team=user_dict.get("team"),
+        guild_id=user_dict["guild_id"],
+        discord_roles=user_dict.get("discord_roles", []),
+    )
+
+    if dispatch_type == "command":
+        response = handle_override_update(interaction, user)
+        post_follow_up(
+            settings.DISCORD_APPLICATION_ID,
+            interaction["token"],
+            response["data"],
+        )
+        return {"statusCode": 200}
+    else:
+        # Route to the correct component handler based on custom_id prefix
+        custom_id = interaction.get("data", {}).get("custom_id", "")
+        if custom_id.startswith(OVERRIDE_MEAL_PREFIX):
+            return handle_override_meal(interaction, user)
+        if custom_id.startswith(OVERRIDE_LOC_PREFIX):
+            return handle_override_location(interaction, user)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"content": "❌ Unknown override component.", "flags": 64},
         }

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -4,8 +4,6 @@ from typing import Any, Dict
 
 from src.handlers.auth import AuthenticatedUser
 from src.models import MealType, WorkLocationType, UserRole
-from src.config import settings
-from src.services.discord_follow_up import post_follow_up
 from src.services.override_service import override_service
 from src.services.meal_service import MEAL_DISPLAY, DEFAULT_MEAL_TYPES
 from src.services.location_service import LOCATION_DISPLAY
@@ -466,13 +464,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     )
 
     if dispatch_type == "command":
-        response = handle_override_update(interaction, user)
-        post_follow_up(
-            settings.DISCORD_APPLICATION_ID,
-            interaction["token"],
-            response["data"],
-        )
-        return {"statusCode": 200}
+        return handle_override_update(interaction, user)
     else:
         # Route to the correct component handler based on custom_id prefix
         custom_id = interaction.get("data", {}).get("custom_id", "")

--- a/Task2_mhp_discord-bot/backend/src/services/discord_follow_up.py
+++ b/Task2_mhp_discord-bot/backend/src/services/discord_follow_up.py
@@ -1,0 +1,25 @@
+import json
+import logging
+import urllib.request
+import urllib.error
+
+logger = logging.getLogger(__name__)
+
+
+def post_follow_up(application_id: str, interaction_token: str, data: dict) -> None:
+    url = f"https://discord.com/api/v10/webhooks/{application_id}/{interaction_token}"
+    body = json.dumps(data).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        urllib.request.urlopen(req, timeout=5)
+    except urllib.error.HTTPError as e:
+        logger.error(f"Discord follow-up failed: {e.code} {e.read().decode()}")
+        raise
+    except urllib.error.URLError as e:
+        logger.error(f"Discord follow-up network error: {e.reason}")
+        raise

--- a/Task2_mhp_discord-bot/backend/src/services/discord_follow_up.py
+++ b/Task2_mhp_discord-bot/backend/src/services/discord_follow_up.py
@@ -7,13 +7,17 @@ logger = logging.getLogger(__name__)
 
 
 def post_follow_up(application_id: str, interaction_token: str, data: dict) -> None:
-    url = f"https://discord.com/api/v10/webhooks/{application_id}/{interaction_token}"
-    body = json.dumps(data).encode()
+    url = f"https://discord.com/api/v10/webhooks/{application_id}/{interaction_token}/messages/@original"
+    patch_data = {k: v for k, v in data.items() if k != "flags"}
+    body = json.dumps(patch_data).encode()
     req = urllib.request.Request(
         url,
         data=body,
-        method="POST",
-        headers={"Content-Type": "application/json"},
+        method="PATCH",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "DiscordBot (https://discord.com/developers/docs, 1.0)",
+        },
     )
     try:
         urllib.request.urlopen(req, timeout=5)


### PR DESCRIPTION
## Related Issues
* Fixes #48

## Summary
Splits the monolithic Lambda into a front-door `IngressFunction` and three dedicated feature Lambdas (Meal, Location, Override), controlled by an `ENABLE_MULTI_LAMBDA` feature flag that defaults to `false` for zero-behavior-change deployment.

## Dependencies
* Depends on Issues #49 & #50 (DynamoDB schema redesign)
* PR #52 

## Changes

### New Files:
- `src/handlers/ingress.py`: new Lambda entry point; handles signature verification, auth, and dispatch; falls back to in-process routing when `ENABLE_MULTI_LAMBDA=false`.
- `src/handlers/dispatcher.py`: maps command names and component `custom_id` prefixes to feature Lambda function names; wraps `boto3.client("lambda").invoke()` with async/sync mode.
- `src/services/discord_follow_up.py`: posts follow-up messages to Discord webhook API using `stdlib` `urllib` only; used by feature Lambdas after async slash command dispatch.

### Modified Files:
- `src/handlers/meal_handler.py`: added `lambda_handler(event, context)` entry point; reconstructs `AuthenticatedUser` from dispatched payload, calls existing handler functions, posts follow-up for slash commands
- `src/handlers/location_handler.py`: same pattern as meal handler
- `src/handlers/override_handler.py`: same pattern; additionally routes component interactions by `custom_id` prefix (`override_meal` vs `override_loc`) within the feature Lambda
- `src/config.py`: added `ENABLE_MULTI_LAMBDA: bool`, `MEAL_FUNCTION_NAME`, `LOCATION_FUNCTION_NAME`, `OVERRIDE_FUNCTION_NAME` settings read from env vars

### Retained:
- `src/handlers/interaction.py`: kept as reference; no longer the deployed entry point

## Context
The single-Lambda design centralises signature verification, auth, command routing, and all feature logic in one runtime. As feature scope grows this increases blast radius, cold-start impact, and deployment risk. This refactor introduces function-level isolation while keeping the existing behaviour fully intact behind a feature flag.

Dispatch strategy: slash commands (type 2) receive a Discord deferred response (type 5) immediately, then the feature Lambda is invoked asynchronously (`InvocationType=Event`) and posts a follow-up via the Discord webhook. Component interactions (type 3 — button clicks) use synchronous invocation (`InvocationType=RequestResponse`) since they are fast DynamoDB operations requiring immediate UI feedback.

## How to Test (if applicable)

- [Ingress Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-ingress?newFunction=true&tab=code)
- [Meal Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-meal?newFunction=true&tab=code)
- [Override Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-override?newFunction=true&tab=code)
- [Location Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-location?newFunction=true&tab=code)

1. Verify feature Lambdas are deployed in the AWS Console: confirm trainee-2026-niloy-mhp-meal-{env}, -location-{env}, -override-{env} appear in Lambda with status Active.
2. Invoke a feature Lambda directly from the AWS Console using a test payload to confirm DynamoDB connectivity and cold-start behaviour before enabling dispatch.
3. Enable multi-Lambda dispatch:
Update the ENABLE_MULTI_LAMBDA env var to "true" on the IngressFunction in the AWS Console, then run a real /meal-update slash command in Discord and confirm the bot responds with the deferred "thinking..." indicator followed by the meal embed.

## Checklist (select options which are applicable)
- [x] Code builds successfully
- [x] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
