### PR TITLE
PR 25: Wire adapter architecture for Issue #2.18 into handlers with Google Chat ingress, link-identity, and bug fixes

### DIFF
--- a/Task2_mhp_discord-bot/backend/requirements-dev.txt
+++ b/Task2_mhp_discord-bot/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+boto3==1.37.0
+aws-lambda-powertools==3.1.0
+pytest==8.3.4
+pytest-asyncio==0.25.3
+moto==5.1.0

--- a/Task2_mhp_discord-bot/backend/requirements.txt
+++ b/Task2_mhp_discord-bot/backend/requirements.txt
@@ -1,7 +1,3 @@
-# AWS Lambda
-boto3==1.37.0
-aws-lambda-powertools==3.1.0
-
 # Discord interactions
 discord-interactions==0.4.0
 PyNaCl==1.5.0
@@ -16,8 +12,7 @@ tzdata==2025.3
 
 # HTTP client
 httpx==0.28.1
+requests>=2.32.0
 
-# Testing
-pytest==8.3.4
-pytest-asyncio==0.25.3
-moto==5.1.0
+# Google Chat integration (feature-flagged via ENABLE_GOOGLE_CHAT)
+google-auth>=2.29.0

--- a/Task2_mhp_discord-bot/backend/src/config.py
+++ b/Task2_mhp_discord-bot/backend/src/config.py
@@ -43,6 +43,13 @@ class Settings(BaseModel):
     LOCATION_FUNCTION_NAME: str = ""
     OVERRIDE_FUNCTION_NAME: str = ""
 
+    # Google Chat integration (feature-flagged)
+    ENABLE_GOOGLE_CHAT: bool = False
+    GOOGLE_CHAT_AUDIENCE: str = ""   
+    GOOGLE_CHAT_ADMIN_EMAILS: str = ""
+    GOOGLE_CHAT_TEAM_LEAD_EMAILS: str = ""
+    GOOGLE_CHAT_SERVICE_ACCOUNT_JSON: str = ""  # base64-encoded service account JSON key
+
 @lru_cache()
 def get_settings() -> Settings:
     return Settings(
@@ -53,9 +60,6 @@ def get_settings() -> Settings:
         DISCORD_CLIENT_ID=os.getenv("DISCORD_CLIENT_ID", ""),
         DISCORD_CLIENT_SECRET=os.getenv("DISCORD_CLIENT_SECRET", ""),
         DISCORD_REDIRECT_URI=os.getenv("DISCORD_REDIRECT_URI", ""),
-        ROLE_ADMIN=os.getenv("ROLE_ADMIN", "MHP-Admin"),
-        ROLE_TEAM_LEAD=os.getenv("ROLE_TEAM_LEAD", "MHP-TeamLead"),
-        ROLE_EMPLOYEE=os.getenv("ROLE_EMPLOYEE", "MHP-Employee"),
         ROLE_ADMIN_ID=os.getenv("ROLE_ADMIN_ID", ""),
         ROLE_TEAM_LEAD_ID=os.getenv("ROLE_TEAM_LEAD_ID", ""),
         DYNAMODB_TABLE_NAME=os.getenv("DYNAMODB_TABLE_NAME", "MHP-Data"),
@@ -70,5 +74,10 @@ def get_settings() -> Settings:
         MEAL_FUNCTION_NAME=os.getenv("MEAL_FUNCTION_NAME", ""),
         LOCATION_FUNCTION_NAME=os.getenv("LOCATION_FUNCTION_NAME", ""),
         OVERRIDE_FUNCTION_NAME=os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+        ENABLE_GOOGLE_CHAT=os.getenv("ENABLE_GOOGLE_CHAT", "false").lower() == "true",
+        GOOGLE_CHAT_AUDIENCE=os.getenv("GOOGLE_CHAT_AUDIENCE", ""),
+        GOOGLE_CHAT_ADMIN_EMAILS=os.getenv("GOOGLE_CHAT_ADMIN_EMAILS", ""),
+        GOOGLE_CHAT_TEAM_LEAD_EMAILS=os.getenv("GOOGLE_CHAT_TEAM_LEAD_EMAILS", ""),
+        GOOGLE_CHAT_SERVICE_ACCOUNT_JSON=os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON", ""),
     )
 settings = get_settings()

--- a/Task2_mhp_discord-bot/backend/src/handlers/auth.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/auth.py
@@ -2,9 +2,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from src.config import settings
 from src.models import UserRole
-from src.services.discord_helpers import extract_team_from_roles
 
 logger = logging.getLogger(__name__)
 
@@ -19,81 +17,36 @@ ROLE_HIERARCHY = {
 
 @dataclass
 class AuthenticatedUser:
-    discord_id: str
+    user_id: str                    # platform-agnostic opaque ID
     username: str
-    global_name: Optional[str]
+    display_name: Optional[str]     # Discord global_name / Google Chat displayName
     role: UserRole
     team: Optional[str]
-    guild_id: str
-    discord_roles: list[str]  # Raw Discord role IDs
+    space_id: str                   # Discord guild_id / Google Chat space name
+    platform_roles: list[str]       # raw platform role IDs
+    platform: str = "discord"       # "discord" | "google_chat"
 
 
 def get_role_hierarchy_level(role: UserRole) -> int:
     return ROLE_HIERARCHY.get(role, 0)
 
 
-def map_discord_roles_to_app_role(discord_roles: list[str]) -> tuple[UserRole, Optional[str]]:
-    if settings.ROLE_ADMIN_ID and settings.ROLE_ADMIN_ID in discord_roles:
-        return UserRole.ADMIN, None
-    
-    if settings.ROLE_TEAM_LEAD_ID and settings.ROLE_TEAM_LEAD_ID in discord_roles:
-        # TODO: Derive team from Discord role name (e.g., "Team-Backend")
-        return UserRole.TEAM_LEAD, None
-    
-    # Log warning if user has roles but no mapping configured
-    if discord_roles and not settings.ROLE_ADMIN_ID:
-        logger.warning(
-            f"Role mapping not configured: ROLE_ADMIN_ID is not set. "
-            f"User Discord roles {discord_roles} cannot be mapped to application roles. "
-            f"Defaulting to EMPLOYEE. Please configure ROLE_ADMIN_ID and ROLE_TEAM_LEAD_ID."
-        )
-    
-    # Default to Employee
-    return UserRole.EMPLOYEE, None
-
-
 def get_user_from_interaction(interaction: dict) -> AuthenticatedUser:
-    member = interaction.get("member", {})
-    user = interaction.get("user", {})
     
-    discord_id = member.get("user", {}).get("id") or user.get("id", "")
-    username = member.get("user", {}).get("username") or user.get("username", "")
-    global_name = member.get("user", {}).get("global_name") or user.get("global_name")
-    discord_roles = member.get("roles", [])
-    guild_id = member.get("guild_id") or interaction.get("guild_id", "")
-    
-    # Map Discord roles to application role
-    app_role, _ = map_discord_roles_to_app_role(discord_roles)
-    
-    # Derive team from Discord roles via DynamoDB policy (team_role_map)
-    team = extract_team_from_roles(discord_roles)
-    
-    logger.info(
-        f"Authenticated user: {username} ({discord_id}) - Role: {app_role.value}, "
-        f"Team: {team}, Discord roles: {discord_roles}"
-    )
-    
-    return AuthenticatedUser(
-        discord_id=discord_id,
-        username=username,
-        global_name=global_name,
-        role=app_role,
-        team=team,
-        guild_id=guild_id,
-        discord_roles=discord_roles,
-    )
+    from src.adapters.discord.auth_adapter import DiscordUserResolver
+    return DiscordUserResolver().resolve(interaction)
 
 
 def authorize_command(
-    user: AuthenticatedUser, 
+    user: AuthenticatedUser,
     required_role: UserRole
 ) -> tuple[bool, Optional[str]]:
     user_level = get_role_hierarchy_level(user.role)
     required_level = get_role_hierarchy_level(required_role)
-    
+
     if user_level < required_level:
         return False, f"❌ You don't have permission to use this command. Required role: {required_role.value}"
-    
+
     return True, None
 
 
@@ -101,6 +54,7 @@ def authorize_command(
 COMMAND_ROLE_REQUIREMENTS = {
     "meal-update": UserRole.EMPLOYEE,
     "work-location": UserRole.EMPLOYEE,
+    "link-identity": UserRole.EMPLOYEE,   
     "team-summary": UserRole.TEAM_LEAD,
     "headcount-summary": UserRole.ADMIN,
     "override-update": UserRole.TEAM_LEAD,
@@ -113,9 +67,9 @@ def check_command_authorization(
     user: AuthenticatedUser
 ) -> tuple[bool, Optional[str]]:
     required_role = COMMAND_ROLE_REQUIREMENTS.get(command_name.lower())
-    
+
     if required_role is None:
         logger.warning(f"Command '{command_name}' has no role requirement defined")
         return True, None
-    
+
     return authorize_command(user, required_role)

--- a/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
@@ -1,0 +1,215 @@
+"""Google Chat Lambda entry point."""
+import base64
+import json
+import logging
+import urllib.request
+from typing import Any, Dict, Optional
+
+from src.adapters.google_chat.verifier import GoogleChatVerifier
+from src.adapters.google_chat.auth_adapter import GoogleChatUserResolver
+from src.adapters.google_chat.renderer import GoogleChatRenderer
+from src.adapters.google_chat.ingress_adapter import GoogleChatIngressAdapter
+from src.handlers.auth import check_command_authorization
+from src.handlers.meal_handler import (
+    handle_meal_update,
+    handle_meal_toggle,
+    MEAL_TOGGLE_PREFIX,
+)
+from src.handlers.location_handler import (
+    handle_work_location,
+    handle_location_set,
+    LOCATION_SET_PREFIX,
+)
+from src.handlers.override_handler import (
+    handle_override_update,
+    handle_override_meal,
+    handle_override_location,
+    OVERRIDE_MEAL_PREFIX,
+    OVERRIDE_LOC_PREFIX,
+)
+from src.handlers.link_handler import handle_link_identity
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Module-level singletons (reused across warm invocations)
+_verifier = GoogleChatVerifier()
+_resolver = GoogleChatUserResolver()
+_renderer = GoogleChatRenderer()
+_adapter = GoogleChatIngressAdapter()
+
+_CHAT_SCOPES = ["https://www.googleapis.com/auth/chat.bot"]
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    logger.info("Google Chat interaction received")
+
+    if not settings.ENABLE_GOOGLE_CHAT:
+        return {
+            "statusCode": 503,
+            "body": json.dumps({"error": "Google Chat integration not enabled"}),
+        }
+
+    try:
+        if not _verifier.verify(event):
+            return {
+                "statusCode": 401,
+                "body": json.dumps({"error": "Unauthorized"}),
+            }
+
+        body = _verifier.extract_body(event)
+        if not body:
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Failed to parse request body"}),
+            }
+
+        user = _resolver.resolve(body)
+        logger.info(f"Google Chat user: {user.username} ({user.user_id}), role: {user.role.value}")
+
+        normalized = _adapter.normalize(body, user)
+        if not normalized:
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Unsupported event type"}),
+            }
+
+        # Authorization check for commands
+        if normalized.interaction_type == "command" and normalized.command_name:
+            is_authorized, error_msg = check_command_authorization(normalized.command_name, user)
+            if not is_authorized:
+                response = _renderer.render_error(error_msg)
+                return _ok(response)
+
+        if normalized.interaction_type == "command":
+            response = _route_command(normalized)
+        else:
+            response = _route_action(normalized)
+
+        if normalized.interaction_type == "action":
+            # Button clicks: respond synchronously (Google Chat requires it)
+            return _ok(_unwrap_render_actions(response))
+        else:
+            # Slash commands: respond asynchronously via Chat REST API
+            space_name = _extract_space_name(body)
+            _post_to_chat(space_name, response)
+            return _ok({})
+
+    except Exception as e:
+        logger.exception(f"Error handling Google Chat interaction: {e}")
+        return _ok({"text": "❌ An error occurred processing your request"})
+
+
+def _route_command(normalized) -> Dict[str, Any]:
+    cmd = normalized.command_name or ""
+    if cmd == "meal-update":
+        return handle_meal_update(normalized, _renderer)
+    if cmd == "work-location":
+        return handle_work_location(normalized, _renderer)
+    if cmd == "override-update":
+        return handle_override_update(normalized, _renderer)
+    if cmd == "link-identity":
+        return handle_link_identity(normalized, _renderer)
+    return _renderer.render_error(f"Unknown command: `{cmd}`")
+
+
+def _route_action(normalized) -> Dict[str, Any]:
+    aid = normalized.action_id or ""
+    if aid.startswith(MEAL_TOGGLE_PREFIX):
+        return handle_meal_toggle(normalized, _renderer)
+    if aid.startswith(LOCATION_SET_PREFIX):
+        return handle_location_set(normalized, _renderer)
+    if aid.startswith(OVERRIDE_MEAL_PREFIX):
+        return handle_override_meal(normalized, _renderer)
+    if aid.startswith(OVERRIDE_LOC_PREFIX):
+        return handle_override_location(normalized, _renderer)
+    return _renderer.render_error("Unknown action")
+
+
+def _unwrap_render_actions(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract the inner message dict from a renderActions wrapper, or return as-is."""
+    try:
+        return response["renderActions"]["hostAppAction"]["chatAction"]["createMessageAction"]["message"]
+    except (KeyError, TypeError):
+        return response
+
+
+def _extract_space_name(body: Dict[str, Any]) -> Optional[str]:
+    chat = body.get("chat") or {}
+    app_cmd = chat.get("appCommandPayload") or {}
+    btn = chat.get("buttonClickedPayload") or {}
+    space = (
+        app_cmd.get("space") or
+        btn.get("space") or
+        (btn.get("message") or {}).get("space") or
+        chat.get("space") or
+        body.get("space") or {}
+    )
+    return space.get("name")
+
+
+def _get_chat_access_token() -> Optional[str]:
+    sa_json_b64 = settings.GOOGLE_CHAT_SERVICE_ACCOUNT_JSON
+    if not sa_json_b64:
+        logger.error("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON not configured")
+        return None
+    try:
+        from google.oauth2 import service_account
+        sa_info = json.loads(base64.b64decode(sa_json_b64 + "==").decode())
+        creds = service_account.Credentials.from_service_account_info(
+            sa_info, scopes=_CHAT_SCOPES
+        )
+        creds.refresh(_SimpleRequest())
+        return creds.token
+    except Exception as e:
+        logger.error("Failed to get Chat API access token: %s", e)
+        return None
+
+
+def _post_to_chat(space_name: Optional[str], message: Dict[str, Any]) -> None:
+    if not space_name:
+        logger.error("No space name — cannot post async message")
+        return
+    token = _get_chat_access_token()
+    if not token:
+        return
+
+    url = f"https://chat.googleapis.com/v1/{space_name}/messages"
+    body_bytes = json.dumps(_unwrap_render_actions(message)).encode()
+    req = urllib.request.Request(
+        url,
+        data=body_bytes,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            logger.info("Posted to Chat API: %s", resp.status)
+    except Exception as e:
+        logger.error("Failed to post to Chat API: %s", e)
+
+
+class _SimpleRequest:
+    """Minimal google-auth transport Request using stdlib urllib."""
+    def __call__(self, url, method="GET", body=None, headers=None, timeout=None, **kwargs):
+        req = urllib.request.Request(url, data=body, headers=headers or {}, method=method)
+        try:
+            resp = urllib.request.urlopen(req, timeout=timeout or 30)
+            return _SimpleResponse(resp.status, dict(resp.headers), resp.read())
+        except urllib.error.HTTPError as e:
+            return _SimpleResponse(e.code, {}, e.read())
+
+
+class _SimpleResponse:
+    def __init__(self, status, headers, data):
+        self.status = status
+        self.headers = headers
+        self.data = data
+
+
+def _ok(response: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(response),
+    }

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -1,17 +1,12 @@
 import json
 import logging
-import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-from nacl.signing import VerifyKey
-from nacl.encoding import RawEncoder
-
-from src.config import settings
-from src.handlers.auth import (
-    AuthenticatedUser,
-    get_user_from_interaction as auth_get_user,
-    check_command_authorization,
-)
+from src.adapters.discord.verifier import DiscordVerifier
+from src.adapters.discord.auth_adapter import DiscordUserResolver
+from src.adapters.discord.ingress_adapter import DiscordIngressAdapter, INTERACTION_PING
+from src.adapters.discord.renderer import DiscordRenderer
+from src.handlers.auth import check_command_authorization
 from src.handlers.meal_handler import (
     handle_meal_update,
     handle_meal_toggle,
@@ -29,67 +24,38 @@ from src.handlers.override_handler import (
     OVERRIDE_MEAL_PREFIX,
     OVERRIDE_LOC_PREFIX,
 )
+from src.handlers.link_handler import handle_link_identity
 from src.handlers import dispatcher
-from src.models import UserRole
+from src.config import settings
 
 logger = logging.getLogger(__name__)
 
 # Discord interaction types
-INTERACTION_PING = 1
 INTERACTION_APPLICATION_COMMAND = 2
 INTERACTION_MESSAGE_COMPONENT = 3
 
 # Discord response types
 RESPONSE_PONG = 1
 RESPONSE_CHANNEL_MESSAGE = 4
-RESPONSE_DEFERRED_CHANNEL_MESSAGE = 5
-RESPONSE_DEFERRED_UPDATE_MESSAGE = 6
-RESPONSE_UPDATE_MESSAGE = 7
 
-# ── Signature verification ────────────────────────────────────────────────────
-
-def verify_signature(event_body: str, signature: str, timestamp: str) -> bool:
-    try:
-        public_key = settings.DISCORD_PUBLIC_KEY
-        if not public_key:
-            logger.error("DISCORD_PUBLIC_KEY not configured")
-            return False
-        verify_key = VerifyKey(bytes.fromhex(public_key))
-        message = timestamp.encode() + event_body.encode()
-        verify_key.verify(message, bytes.fromhex(signature), encoder=RawEncoder)
-        return True
-    except Exception as e:
-        logger.error(f"Signature verification failed: {e}")
-        return False
+# Module-level adapter singletons (reused across warm Lambda invocations)
+_verifier = DiscordVerifier()
+_resolver = DiscordUserResolver()
+_ingress_adapter = DiscordIngressAdapter()
+_renderer = DiscordRenderer()
 
 
-def parse_interaction(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    headers = event.get("headers", {}) or {}
-    signature = headers.get("X-Signature-Ed25519") or headers.get("x-signature-ed25519")
-    timestamp = headers.get("X-Signature-Timestamp") or headers.get("x-signature-timestamp")
-    body = event.get("body", "")
-
-    if settings.DEBUG and os.getenv("SKIP_SIGNATURE_VERIFICATION"):
-        logger.warning("Signature verification skipped (DEBUG mode)")
-    elif not signature or not timestamp:
-        logger.error("Missing signature or timestamp headers")
-        return None
-    elif not verify_signature(body, signature, timestamp):
-        logger.error("Invalid signature")
-        return None
-
-    try:
-        if event.get("isBase64Encoded"):
-            import base64
-            body = base64.b64decode(body).decode("utf-8")
-        return json.loads(body)
-    except json.JSONDecodeError as e:
-        logger.error(f"Failed to parse JSON: {e}")
-        return None
-
-
-def get_command_name(interaction: Dict[str, Any]) -> str:
-    return interaction.get("data", {}).get("name", "")
+def _serialize_user(user) -> Dict[str, Any]:
+    return {
+        "user_id": user.user_id,
+        "username": user.username,
+        "display_name": user.display_name,
+        "role": user.role.value,
+        "team": user.team,
+        "space_id": user.space_id,
+        "platform_roles": user.platform_roles,
+        "platform": user.platform,
+    }
 
 
 def create_error_response(message: str) -> Dict[str, Any]:
@@ -99,106 +65,77 @@ def create_error_response(message: str) -> Dict[str, Any]:
     }
 
 
-def _deferred_response() -> Dict[str, Any]:
-    return {"type": RESPONSE_DEFERRED_CHANNEL_MESSAGE, "data": {"flags": 64}}
-
-
-def _serialize_user(user: AuthenticatedUser) -> Dict[str, Any]:
-    return {
-        "discord_id": user.discord_id,
-        "username": user.username,
-        "global_name": user.global_name,
-        "role": user.role.value,
-        "team": user.team,
-        "guild_id": user.guild_id,
-        "discord_roles": user.discord_roles,
-    }
-
 # ── In-process routing (fallback path) ───────────────────────────────────────
 
-def _route_command_inprocess(
-    interaction: Dict[str, Any], user: AuthenticatedUser
-) -> Dict[str, Any]:
-    command_name = get_command_name(interaction)
-    logger.info(f"In-process routing command: {command_name}")
+def _route_inprocess(normalized, interaction_type: int) -> Dict[str, Any]:
+    if interaction_type == INTERACTION_APPLICATION_COMMAND:
+        cmd = normalized.command_name or ""
+        logger.info(f"In-process routing command: {cmd}")
+        if cmd == "meal-update":
+            return handle_meal_update(normalized, _renderer)
+        if cmd == "work-location":
+            return handle_work_location(normalized, _renderer)
+        if cmd == "override-update":
+            return handle_override_update(normalized, _renderer)
+        if cmd == "link-identity":
+            return handle_link_identity(normalized, _renderer)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {
+                "content": f"🔧 Command `{cmd}` is being implemented. Stay tuned!\n\nYour role: {normalized.user.role.value}",
+                "flags": 64,
+            },
+        }
+    else:  # MESSAGE_COMPONENT
+        aid = normalized.action_id or ""
+        if aid.startswith(MEAL_TOGGLE_PREFIX):
+            return handle_meal_toggle(normalized, _renderer)
+        if aid.startswith(LOCATION_SET_PREFIX):
+            return handle_location_set(normalized, _renderer)
+        if aid.startswith(OVERRIDE_MEAL_PREFIX):
+            return handle_override_meal(normalized, _renderer)
+        if aid.startswith(OVERRIDE_LOC_PREFIX):
+            return handle_override_location(normalized, _renderer)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"content": "🔧 Component interactions are being implemented.", "flags": 64},
+        }
 
-    if command_name == "meal-update":
-        return handle_meal_update(interaction, user)
-    if command_name == "work-location":
-        return handle_work_location(interaction, user)
-    if command_name == "override-update":
-        return handle_override_update(interaction, user)
-
-    return {
-        "type": RESPONSE_CHANNEL_MESSAGE,
-        "data": {
-            "content": f"🔧 Command `{command_name}` is being implemented. Stay tuned!\n\nYour role: {user.role.value}",
-            "flags": 64,
-        },
-    }
-
-
-def _route_component_inprocess(
-    interaction: Dict[str, Any], user: AuthenticatedUser
-) -> Dict[str, Any]:
-    custom_id = interaction.get("data", {}).get("custom_id", "")
-
-    if custom_id.startswith(MEAL_TOGGLE_PREFIX):
-        return handle_meal_toggle(interaction, user)
-    if custom_id.startswith(LOCATION_SET_PREFIX):
-        return handle_location_set(interaction, user)
-    if custom_id.startswith(OVERRIDE_MEAL_PREFIX):
-        return handle_override_meal(interaction, user)
-    if custom_id.startswith(OVERRIDE_LOC_PREFIX):
-        return handle_override_location(interaction, user)
-
-    return {
-        "type": RESPONSE_CHANNEL_MESSAGE,
-        "data": {"content": "🔧 Component interactions are being implemented.", "flags": 64},
-    }
 
 # ── Multi-Lambda dispatch path ────────────────────────────────────────────────
 
-def _dispatch_command(
-    interaction: Dict[str, Any], user: AuthenticatedUser
-) -> Dict[str, Any]:
-    command_name = get_command_name(interaction)
-    fn = dispatcher.get_function_for_command(command_name)
+def _dispatch(normalized, interaction_type: int) -> Dict[str, Any]:
+    if interaction_type == INTERACTION_APPLICATION_COMMAND:
+        cmd = normalized.command_name or ""
+        fn = dispatcher.get_function_for_command(cmd)
+        if not fn:
+            logger.warning(f"No feature Lambda for command: {cmd}")
+            return _route_inprocess(normalized, interaction_type)
+        payload = {
+            "dispatch_type": "command",
+            "command_name": cmd,
+            "options": normalized.options,
+            "interaction": normalized.raw_body,
+            "user": _serialize_user(normalized.user),
+        }
+    else:  # MESSAGE_COMPONENT
+        aid = normalized.action_id or ""
+        fn = dispatcher.get_function_for_component(aid)
+        if not fn:
+            logger.warning(f"No feature Lambda for component: {aid}")
+            return _route_inprocess(normalized, interaction_type)
+        payload = {
+            "dispatch_type": "component",
+            "action_id": aid,
+            "interaction": normalized.raw_body,
+            "user": _serialize_user(normalized.user),
+        }
 
-    if not fn:
-        logger.warning(f"No feature Lambda configured for command: {command_name}")
-        return _route_command_inprocess(interaction, user)
-
-    payload = {
-        "dispatch_type": "command",
-        "interaction": interaction,
-        "user": _serialize_user(user),
-    }
     result = dispatcher.dispatch(fn, payload, async_mode=False)
     if result is None:
         return create_error_response("Feature Lambda returned no response.")
     return result
 
-
-def _dispatch_component(
-    interaction: Dict[str, Any], user: AuthenticatedUser
-) -> Dict[str, Any]:
-    custom_id = interaction.get("data", {}).get("custom_id", "")
-    fn = dispatcher.get_function_for_component(custom_id)
-
-    if not fn:
-        logger.warning(f"No feature Lambda configured for component: {custom_id}")
-        return _route_component_inprocess(interaction, user)
-
-    payload = {
-        "dispatch_type": "component",
-        "interaction": interaction,
-        "user": _serialize_user(user),
-    }
-    result = dispatcher.dispatch(fn, payload, async_mode=False)
-    if result is None:
-        return create_error_response("Feature Lambda returned no response.")
-    return result
 
 # ── Lambda entry point ────────────────────────────────────────────────────────
 
@@ -206,14 +143,20 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     logger.info(f"Received event: {event.get('httpMethod')} {event.get('path')}")
 
     try:
-        interaction = parse_interaction(event)
-        if not interaction:
+        if not _verifier.verify(event):
             return {
                 "statusCode": 401,
                 "body": json.dumps({"error": "Invalid signature"}),
             }
 
-        interaction_type = interaction.get("type")
+        body = _verifier.extract_body(event)
+        if not body:
+            return {
+                "statusCode": 400,
+                "body": json.dumps({"error": "Failed to parse request body"}),
+            }
+
+        interaction_type = body.get("type")
 
         if interaction_type == INTERACTION_PING:
             logger.info("Responding to PING")
@@ -223,38 +166,31 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "body": json.dumps({"type": RESPONSE_PONG}),
             }
 
-        user = auth_get_user(interaction)
-        logger.info(
-            f"User authenticated: {user.username} ({user.discord_id}), role: {user.role.value}"
-        )
+        user = _resolver.resolve(body)
+        logger.info(f"User authenticated: {user.username} ({user.user_id}), role: {user.role.value}")
 
-        # Authorization check (applies to both routing paths)
-        command_name = get_command_name(interaction) if interaction_type == INTERACTION_APPLICATION_COMMAND else ""
-        if command_name:
-            is_authorized, error_msg = check_command_authorization(command_name, user)
+        normalized = _ingress_adapter.normalize(body, user)
+        if not normalized:
+            return {
+                "statusCode": 200,
+                "headers": {"Content-Type": "application/json"},
+                "body": json.dumps(create_error_response(f"Unknown interaction type: {interaction_type}")),
+            }
+
+        # Authorization check for commands
+        if normalized.interaction_type == "command" and normalized.command_name:
+            is_authorized, error_msg = check_command_authorization(normalized.command_name, user)
             if not is_authorized:
-                response = create_error_response(error_msg)
                 return {
                     "statusCode": 200,
                     "headers": {"Content-Type": "application/json"},
-                    "body": json.dumps(response),
+                    "body": json.dumps(create_error_response(error_msg)),
                 }
 
         if settings.ENABLE_MULTI_LAMBDA:
-            if interaction_type == INTERACTION_APPLICATION_COMMAND:
-                response = _dispatch_command(interaction, user)
-            elif interaction_type == INTERACTION_MESSAGE_COMPONENT:
-                response = _dispatch_component(interaction, user)
-            else:
-                response = create_error_response(f"Unknown interaction type: {interaction_type}")
+            response = _dispatch(normalized, interaction_type)
         else:
-            # Fallback: in-process routing (same as original interaction.py)
-            if interaction_type == INTERACTION_APPLICATION_COMMAND:
-                response = _route_command_inprocess(interaction, user)
-            elif interaction_type == INTERACTION_MESSAGE_COMPONENT:
-                response = _route_component_inprocess(interaction, user)
-            else:
-                response = create_error_response(f"Unknown interaction type: {interaction_type}")
+            response = _route_inprocess(normalized, interaction_type)
 
         return {
             "statusCode": 200,

--- a/Task2_mhp_discord-bot/backend/src/handlers/link_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/link_handler.py
@@ -1,0 +1,134 @@
+# Handles /link-identity slash command (Discord and Google Chat)
+#
+# Scope rules:
+#   Admin     → can link any employee (provide employee mention / google_email freely)
+#   Team Lead → can only link themselves
+#   Employee  → can only link themselves
+#
+# Discord:  /link-identity employee:<@mention>  google_email:<email>
+#   - employee option is optional; omitting it means "myself"
+#
+# Google Chat: /link-identity discord_id:<snowflake>  google_email:<email>
+#   - google_email option is optional; omitting it means "myself" (actor's email)
+import logging
+from typing import Any, Dict
+
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
+from src.models import ExternalIdentity, UserRole
+from src.storage.dynamodb import storage
+
+logger = logging.getLogger(__name__)
+
+
+def handle_link_identity(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    try:
+        if interaction.user.platform == "google_chat":
+            return _handle_google_chat_link(interaction, renderer)
+        return _handle_discord_link(interaction, renderer)
+    except Exception as e:
+        logger.exception("Error handling link-identity: %s", e)
+        return renderer.render_error("An error occurred while linking identities. Please try again.")
+
+
+# ── Discord path ──────────────────────────────────────────────────────────────
+
+def _handle_discord_link(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    actor = interaction.user
+    options = interaction.options
+
+    google_email = (options.get("google_email") or "").strip().lower()
+    if not google_email:
+        return renderer.render_error(
+            "Please provide the Google Chat email address using the `google_email` option."
+        )
+
+    # employee option is the Discord snowflake of the target user (from mention)
+    target_discord_id = options.get("employee") or actor.user_id
+
+    # Scope check: non-admins can only link themselves
+    if actor.role != UserRole.ADMIN and target_discord_id != actor.user_id:
+        return renderer.render_error(
+            "You can only link your own identity. Admins can link any employee."
+        )
+
+    _write_identity_pair(discord_id=target_discord_id, google_email=google_email)
+
+    logger.info(
+        "Identity linked via Discord: discord=%s ↔ google_chat=%s  (by actor=%s)",
+        target_discord_id, google_email, actor.user_id,
+    )
+
+    if target_discord_id == actor.user_id:
+        msg = f"Your Discord account is now linked to Google Chat email **{google_email}**."
+    else:
+        msg = f"<@{target_discord_id}> is now linked to Google Chat email **{google_email}**."
+
+    return renderer.render_success(msg)
+
+
+# ── Google Chat path ──────────────────────────────────────────────────────────
+
+def _handle_google_chat_link(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    actor = interaction.user
+    options = interaction.options
+
+    discord_id = (options.get("discord_id") or "").strip()
+    if not discord_id:
+        return renderer.render_error(
+            "Please provide the Discord user ID using the `discord_id` option "
+            "(e.g. `/link-identity discord_id:111222333`)."
+        )
+
+    # google_email defaults to the actor's own email when not provided
+    google_email = (options.get("google_email") or actor.username or "").strip().lower()
+    if not google_email:
+        return renderer.render_error(
+            "Could not determine the Google Chat email. Please provide it explicitly "
+            "using the `google_email` option."
+        )
+
+    # Scope check: non-admins can only link their own Google Chat email
+    if actor.role != UserRole.ADMIN and google_email != (actor.username or "").lower():
+        return renderer.render_error(
+            "You can only link your own identity. Admins can link any employee."
+        )
+
+    _write_identity_pair(discord_id=discord_id, google_email=google_email)
+
+    logger.info(
+        "Identity linked via Google Chat: discord=%s ↔ google_chat=%s  (by actor=%s)",
+        discord_id, google_email, actor.user_id,
+    )
+
+    if google_email == (actor.username or "").lower():
+        msg = f"Your Google Chat account is now linked to Discord ID **{discord_id}**."
+    else:
+        msg = f"Google Chat email **{google_email}** is now linked to Discord ID **{discord_id}**."
+
+    return renderer.render_success(msg)
+
+
+# ── Shared write ──────────────────────────────────────────────────────────────
+
+def _write_identity_pair(discord_id: str, google_email: str) -> None:
+    """Write both IDENT items using the Discord snowflake as the canonical user_id."""
+    storage.put_identity(ExternalIdentity(
+        provider="discord",
+        external_id=discord_id,
+        user_id=discord_id,
+    ))
+    storage.put_identity(ExternalIdentity(
+        provider="google_chat",
+        external_id=google_email,
+        user_id=discord_id,
+    ))

--- a/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
@@ -3,262 +3,130 @@ import logging
 from datetime import date
 from typing import Any, Dict
 
-from src.handlers.auth import AuthenticatedUser
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
 from src.models import WorkLocationType, UserRole
-from src.services.location_service import location_service, LOCATION_DISPLAY
-from src.utils import parse_date_option, format_date_display, validate_date_for_update
+from src.services.location_service import location_service
+from src.utils import parse_date_option, validate_date_for_update
 
 logger = logging.getLogger(__name__)
-
-# Discord response types
-RESPONSE_CHANNEL_MESSAGE = 4
-RESPONSE_UPDATE_MESSAGE = 7
-
-# Discord component types
-ACTION_ROW = 1
-BUTTON = 2
-
-# Discord button styles
-BUTTON_PRIMARY = 1    # Blurple
-BUTTON_SECONDARY = 2  # Grey
-BUTTON_SUCCESS = 3    # Green
-BUTTON_DANGER = 4     # Red
 
 # Custom ID prefix for work-location buttons
 LOCATION_SET_PREFIX = "location_set"
 
 
-def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
-    data = interaction.get("data", {})
-    options = data.get("options", [])
-    return {opt["name"]: opt["value"] for opt in options}
-
-
-# ── Embed builder ────────────────────────────────────────────────────────────
-
-def _build_location_status_embed(
-    discord_id: str, target_date: date, confirmation: str | None = None
-) -> Dict[str, Any]:
-    record = location_service.get_user_location_for_date(discord_id, target_date)
-    current = location_service.get_current_location(record)
-    display = location_service.get_location_display_info(current)
-
-    status_line = f"{display['emoji']} **{display['label']}**"
-
-    description_parts = [
-        f"📅 **{format_date_display(target_date)}**",
-        "",
-        f"Current location: {status_line}",
-    ]
-
-    if confirmation:
-        description_parts.insert(2, confirmation)
-        description_parts.insert(3, "")
-
-    description_parts.append("")
-    description_parts.append("Click a button below to change your work location.")
-
-    embed = {
-        "title": "📍 Work Location",
-        "description": "\n".join(description_parts),
-        "color": 0x57F287 if current == WorkLocationType.OFFICE else 0xFEE75C,
-        "footer": {
-            "text": "Default: Office • WFH days count toward monthly cap"
-        },
-    }
-
-    return embed
-
-# ── Button builder ───────────────────────────────────────────────────────────
-
-def _build_location_buttons(
-    discord_id: str, target_date: date
-) -> list[Dict[str, Any]]:
-    record = location_service.get_user_location_for_date(discord_id, target_date)
-    current = location_service.get_current_location(record)
-
-    buttons: list[Dict[str, Any]] = []
-
-    for loc_type in (WorkLocationType.OFFICE, WorkLocationType.WFH):
-        display = location_service.get_location_display_info(loc_type)
-        custom_id = (
-            f"{LOCATION_SET_PREFIX}:{discord_id}:"
-            f"{target_date.isoformat()}:{loc_type.value}"
-        )
-
-        is_active = loc_type == current
-        if is_active:
-            style = BUTTON_SUCCESS
-            label = f"{display['emoji']} {display['label']} ✅"
-        else:
-            style = BUTTON_SECONDARY
-            label = f"{display['emoji']} {display['label']}"
-
-        buttons.append({
-            "type": BUTTON,
-            "style": style,
-            "label": label,
-            "custom_id": custom_id,
-            "disabled": is_active,  # can't re-select the current location
-        })
-
-    return [{"type": ACTION_ROW, "components": buttons}]
-
-# ── Command handler ──────────────────────────────────────────────────────────
-
 def handle_work_location(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        options = _get_command_options(interaction)
-        date_str = options.get("date")
+        date_str = interaction.options.get("date")
 
-        # Parse & validate date
         try:
             target_date = parse_date_option(date_str)
         except ValueError as e:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {e}", "flags": 64},
-            }
+            return renderer.render_error(str(e))
 
         is_valid, error_msg = validate_date_for_update(target_date)
         if not is_valid:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {error_msg}", "flags": 64},
-            }
+            return renderer.render_error(error_msg)
 
-        embed = _build_location_status_embed(user.discord_id, target_date)
-        components = _build_location_buttons(user.discord_id, target_date)
-
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-                "flags": 64,  # Ephemeral
-            },
-        }
+        record = location_service.get_user_location_for_date(interaction.user.user_id, target_date)
+        current = location_service.get_current_location(record)
+        return renderer.render_location_status(interaction.user.user_id, target_date, current)
 
     except Exception as e:
         logger.exception("Error handling work-location: %s", e)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while fetching your work location. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while fetching your work location. Please try again.")
 
-# ── Button interaction handler ───────────────────────────────────────────────
 
 def handle_location_set(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        data = interaction.get("data", {})
-        custom_id = data.get("custom_id", "")
-        # Parse custom_id: location_set:<discord_id>:<date>:<location>
-        parts = custom_id.split(":")
+        action_id = interaction.action_id or ""
+
+        # Parse action_id: location_set:<user_id>:<date>:<location>
+        parts = action_id.split(":")
         if len(parts) != 4 or parts[0] != LOCATION_SET_PREFIX:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": "❌ Invalid button interaction.", "flags": 64},
-            }
+            return renderer.render_error("Invalid button interaction.")
 
         _, target_user_id, date_str, location_str = parts
 
         # Security: only the user themselves can click their own buttons
-        if user.discord_id != target_user_id:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ You can only update your own work location.",
-                    "flags": 64,
-                },
-            }
+        if interaction.user.user_id != target_user_id:
+            return renderer.render_error("You can only update your own work location.")
 
         try:
             target_date = date.fromisoformat(date_str)
         except ValueError:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": "❌ Invalid date format in button.", "flags": 64},
-            }
+            return renderer.render_error("Invalid date format in button.")
+
         try:
             location = WorkLocationType(location_str)
         except ValueError:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": f"❌ Unknown location type: {location_str}",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error(f"Unknown location type: {location_str}")
 
-        # Persist
         success, result = location_service.set_work_location(
-            discord_id=user.discord_id,
+            discord_id=interaction.user.user_id,
             target_date=target_date,
             location=location,
-            updated_by=user.discord_id,
-            team=user.team,
+            updated_by=interaction.user.user_id,
+            team=interaction.user.team,
         )
 
         if not success:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {result}", "flags": 64},
-            }
+            return renderer.render_error(result)
 
-        # Build updated embed with confirmation
-        display = location_service.get_location_display_info(location)
-        confirmation = (
-            f"Updated → {display['emoji']} **{display['label']}**"
+        loc_display_info = location_service.get_location_display_info(location)
+        confirmation = f"Updated → {loc_display_info['emoji']} **{loc_display_info['label']}**"
+        status = renderer.render_location_status(
+            interaction.user.user_id, target_date, location, confirmation=confirmation
         )
-        embed = _build_location_status_embed(
-            user.discord_id, target_date, confirmation=confirmation
-        )
-        components = _build_location_buttons(user.discord_id, target_date)
-
-        return {
-            "type": RESPONSE_UPDATE_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-            },
-        }
+        return renderer.render_update(status)
 
     except Exception as e:
         logger.exception("Error handling location set: %s", e)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while updating your work location. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while updating your work location. Please try again.")
 
 
-# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+# ── Feature Lambda entry point ────────────────────────────────────────────────
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    interaction = event["interaction"]
-    user_dict = event["user"]
-    dispatch_type = event["dispatch_type"]
+    from src.adapters.discord.renderer import DiscordRenderer
+    from src.handlers.auth import AuthenticatedUser
 
+    renderer = DiscordRenderer()
+    user_dict = event["user"]
     user = AuthenticatedUser(
-        discord_id=user_dict["discord_id"],
+        user_id=user_dict["user_id"],
         username=user_dict["username"],
-        global_name=user_dict.get("global_name"),
+        display_name=user_dict.get("display_name"),
         role=UserRole(user_dict["role"]),
         team=user_dict.get("team"),
-        guild_id=user_dict["guild_id"],
-        discord_roles=user_dict.get("discord_roles", []),
+        space_id=user_dict.get("space_id", ""),
+        platform_roles=user_dict.get("platform_roles", []),
+        platform=user_dict.get("platform", "discord"),
     )
 
-    if dispatch_type == "command":
-        return handle_work_location(interaction, user)
+    normalized = NormalizedInteraction(
+        platform=user_dict.get("platform", "discord"),
+        interaction_type=event["dispatch_type"],
+        command_name=event.get("command_name"),
+        action_id=event.get("action_id") or event.get("interaction", {}).get("data", {}).get("custom_id"),
+        options=event.get("options") or _extract_options_from_raw(event.get("interaction", {})),
+        raw_body=event.get("interaction", {}),
+        user=user,
+    )
+
+    if event["dispatch_type"] == "command":
+        return handle_work_location(normalized, renderer)
     else:
-        return handle_location_set(interaction, user)
+        return handle_location_set(normalized, renderer)
+
+
+def _extract_options_from_raw(interaction: Dict[str, Any]) -> Dict[str, Any]:
+    data = interaction.get("data", {})
+    options_list = data.get("options", [])
+    return {opt["name"]: opt["value"] for opt in options_list}

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -3,260 +3,127 @@ import logging
 from datetime import date
 from typing import Any, Dict
 
-from src.handlers.auth import AuthenticatedUser
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
 from src.models import MealType, UserRole
-from src.services.meal_service import meal_service, MEAL_DISPLAY
-from src.utils import parse_date_option, format_date_display, validate_date_for_update
+from src.services.meal_service import meal_service
+from src.utils import parse_date_option, validate_date_for_update
 
 logger = logging.getLogger(__name__)
-
-# Discord response types
-RESPONSE_CHANNEL_MESSAGE = 4
-RESPONSE_UPDATE_MESSAGE = 7
-
-# Discord component types
-ACTION_ROW = 1
-BUTTON = 2
-
-# Discord button styles
-BUTTON_PRIMARY = 1    # Blurple (opted in)
-BUTTON_SECONDARY = 2  # Grey
-BUTTON_SUCCESS = 3    # Green (opted in)
-BUTTON_DANGER = 4     # Red (opted out)
 
 # Custom ID prefix for meal toggle buttons
 MEAL_TOGGLE_PREFIX = "meal_toggle"
 
-def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
-    data = interaction.get("data", {})
-    options = data.get("options", [])
-    return {opt["name"]: opt["value"] for opt in options}
-
-
-def _build_meal_status_embed(
-    discord_id: str, target_date: date
-) -> Dict[str, Any]:
-    meals = meal_service.get_user_meals_for_date(discord_id, target_date)
-
-    fields = []
-    for meal_type, record in meals.items():
-        display = meal_service.get_meal_display_info(meal_type)
-        is_participating = meal_service.get_participation_status(record)
-
-        status_emoji = "✅" if is_participating else "❌"
-        status_text = "Opted In" if is_participating else "Opted Out"
-
-        fields.append({
-            "name": f"{display['emoji']} {display['label']}",
-            "value": f"{status_emoji} {status_text}",
-            "inline": True,
-        })
-
-    embed = {
-        "title": "🍽️ Meal Participation",
-        "description": f"📅 **{format_date_display(target_date)}**\n\nClick a button below to toggle your participation for each meal.",
-        "fields": fields,
-        "color": 0x5865F2,  # Discord blurple
-        "footer": {
-            "text": "Default: Opted In for all meals • Toggle to change"
-        },
-    }
-
-    return embed
-
-
-def _build_meal_toggle_buttons(
-    discord_id: str, target_date: date
-) -> list[Dict[str, Any]]:
-    meals = meal_service.get_user_meals_for_date(discord_id, target_date)
-
-    buttons = []
-    for meal_type, record in meals.items():
-        display = meal_service.get_meal_display_info(meal_type)
-        is_participating = meal_service.get_participation_status(record)
-
-        # custom_id format: meal_toggle:<discord_id>:<date>:<meal_type>
-        custom_id = f"{MEAL_TOGGLE_PREFIX}:{discord_id}:{target_date.isoformat()}:{meal_type.value}"
-
-        if is_participating:
-            style = BUTTON_SUCCESS
-            label = f"{display['emoji']} {display['label']} ✅"
-        else:
-            style = BUTTON_DANGER
-            label = f"{display['emoji']} {display['label']} ❌"
-
-        buttons.append({
-            "type": BUTTON,
-            "style": style,
-            "label": label,
-            "custom_id": custom_id,
-        })
-
-    # Discord allows max 5 buttons per action row
-    rows = []
-    for i in range(0, len(buttons), 5):
-        rows.append({
-            "type": ACTION_ROW,
-            "components": buttons[i:i + 5],
-        })
-
-    return rows
-
 
 def handle_meal_update(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        options = _get_command_options(interaction)
-        date_str = options.get("date")
+        date_str = interaction.options.get("date")
 
         try:
             target_date = parse_date_option(date_str)
         except ValueError as e:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": f"❌ {str(e)}",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error(str(e))
 
         is_valid, error_msg = validate_date_for_update(target_date)
         if not is_valid:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": f"❌ {error_msg}",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error(error_msg)
 
-        embed = _build_meal_status_embed(user.discord_id, target_date)
-        components = _build_meal_toggle_buttons(user.discord_id, target_date)
-
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-                "flags": 64,  # Ephemeral
-            },
-        }
+        meals = meal_service.get_user_meals_for_date(interaction.user.user_id, target_date)
+        return renderer.render_meal_status(interaction.user.user_id, target_date, meals)
 
     except Exception as e:
         logger.exception(f"Error handling meal-update: {e}")
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while fetching your meal status. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while fetching your meal status. Please try again.")
 
 
 def handle_meal_toggle(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        data = interaction.get("data", {})
-        custom_id = data.get("custom_id", "")
+        action_id = interaction.action_id or ""
 
-        # Parse custom_id: meal_toggle:<discord_id>:<date>:<meal_type>
-        parts = custom_id.split(":")
+        # Parse action_id: meal_toggle:<user_id>:<date>:<meal_type>
+        parts = action_id.split(":")
         if len(parts) != 4 or parts[0] != MEAL_TOGGLE_PREFIX:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ Invalid button interaction.",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error("Invalid button interaction.")
 
         _, target_user_id, date_str, meal_type_str = parts
 
         # Security: ensure the clicking user matches the button target
-        if user.discord_id != target_user_id:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ You can only update your own meal participation.",
-                    "flags": 64,
-                },
-            }
+        if interaction.user.user_id != target_user_id:
+            return renderer.render_error("You can only update your own meal participation.")
 
         target_date = date.fromisoformat(date_str)
         meal_type = MealType(meal_type_str)
 
-        # Toggle
         success, result = meal_service.toggle_meal_participation(
-            discord_id=user.discord_id,
+            discord_id=interaction.user.user_id,
             target_date=target_date,
             meal_type=meal_type,
-            updated_by=user.discord_id,
-            team=user.team,
+            updated_by=interaction.user.user_id,
+            team=interaction.user.team,
         )
 
         if not success:
-            # result is an error message string
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": f"❌ {result}",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error(result)
 
-        # Build updated embed + buttons showing new state
-        embed = _build_meal_status_embed(user.discord_id, target_date)
-        components = _build_meal_toggle_buttons(user.discord_id, target_date)
-
-        # Add confirmation text to embed description
+        # Rebuild status with confirmation
+        updated_meals = meal_service.get_user_meals_for_date(interaction.user.user_id, target_date)
         display = meal_service.get_meal_display_info(meal_type)
         status_text = "✅ Opted In" if result.is_participating else "❌ Opted Out"
-        embed["description"] = (
-            f"📅 **{format_date_display(target_date)}**\n\n"
+        confirmation = (
             f"Updated **{display['emoji']} {display['label']}** → {status_text}\n\n"
             f"Click a button below to toggle your participation for each meal."
         )
 
-        # Use UPDATE_MESSAGE to edit the original response in place
-        return {
-            "type": RESPONSE_UPDATE_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-            },
-        }
+        status = renderer.render_meal_status(interaction.user.user_id, target_date, updated_meals, confirmation)
+        return renderer.render_update(status)
 
     except Exception as e:
         logger.exception(f"Error handling meal toggle: {e}")
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while updating your meal status. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while updating your meal status. Please try again.")
 
 
-# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+# ── Feature Lambda entry point ────────────────────────────────────────────────
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    interaction = event["interaction"]
-    user_dict = event["user"]
-    dispatch_type = event["dispatch_type"]
+    from src.adapters.discord.renderer import DiscordRenderer
+    from src.handlers.auth import AuthenticatedUser
 
+    renderer = DiscordRenderer()
+    user_dict = event["user"]
     user = AuthenticatedUser(
-        discord_id=user_dict["discord_id"],
+        user_id=user_dict["user_id"],
         username=user_dict["username"],
-        global_name=user_dict.get("global_name"),
+        display_name=user_dict.get("display_name"),
         role=UserRole(user_dict["role"]),
         team=user_dict.get("team"),
-        guild_id=user_dict["guild_id"],
-        discord_roles=user_dict.get("discord_roles", []),
+        space_id=user_dict.get("space_id", ""),
+        platform_roles=user_dict.get("platform_roles", []),
+        platform=user_dict.get("platform", "discord"),
     )
 
-    if dispatch_type == "command":
-        return handle_meal_update(interaction, user)
+    normalized = NormalizedInteraction(
+        platform=user_dict.get("platform", "discord"),
+        interaction_type=event["dispatch_type"],
+        command_name=event.get("command_name"),
+        action_id=event.get("action_id") or event.get("interaction", {}).get("data", {}).get("custom_id"),
+        options=event.get("options") or _extract_options_from_raw(event.get("interaction", {})),
+        raw_body=event.get("interaction", {}),
+        user=user,
+    )
+
+    if event["dispatch_type"] == "command":
+        return handle_meal_update(normalized, renderer)
     else:
-        return handle_meal_toggle(interaction, user)
+        return handle_meal_toggle(normalized, renderer)
+
+
+def _extract_options_from_raw(interaction: Dict[str, Any]) -> Dict[str, Any]:
+    data = interaction.get("data", {})
+    options_list = data.get("options", [])
+    return {opt["name"]: opt["value"] for opt in options_list}

--- a/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/override_handler.py
@@ -2,327 +2,120 @@ import logging
 from datetime import date
 from typing import Any, Dict
 
-from src.handlers.auth import AuthenticatedUser
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
 from src.models import MealType, WorkLocationType, UserRole
 from src.services.override_service import override_service
-from src.services.meal_service import MEAL_DISPLAY, DEFAULT_MEAL_TYPES
+from src.services.meal_service import MEAL_DISPLAY
 from src.services.location_service import LOCATION_DISPLAY
-from src.services.discord_helpers import extract_team_from_roles
-from src.utils import parse_date_option, format_date_display, validate_date_for_update
+from src.services.team_helpers import extract_team_from_roles
+from src.utils import parse_date_option, validate_date_for_update
 
 logger = logging.getLogger(__name__)
-
-# Discord response types
-RESPONSE_CHANNEL_MESSAGE = 4
-RESPONSE_UPDATE_MESSAGE = 7
-
-# Discord component types
-ACTION_ROW = 1
-BUTTON = 2
-
-# Discord button styles
-BUTTON_PRIMARY = 1    # Blurple
-BUTTON_SECONDARY = 2  # Grey
-BUTTON_SUCCESS = 3    # Green
-BUTTON_DANGER = 4     # Red
 
 # Custom ID prefixes for override buttons
 OVERRIDE_MEAL_PREFIX = "override_meal"
 OVERRIDE_LOC_PREFIX = "override_loc"
 
-# Embed color
-OVERRIDE_EMBED_COLOR = 0xED4245  # Red — distinct from self-service
-
-
-def _get_command_options(interaction: Dict[str, Any]) -> dict[str, Any]:
-    data = interaction.get("data", {})
-    options = data.get("options", [])
-    result: dict[str, Any] = {}
-    for opt in options:
-        if opt.get("type") == 6:  # USER type
-            result[opt["name"]] = opt["value"]
-            # Also capture resolved user data if available
-            resolved = data.get("resolved", {})
-            members = resolved.get("members", {})
-            users = resolved.get("users", {})
-            if opt["value"] in users:
-                result[f"_resolved_user_{opt['name']}"] = users[opt["value"]]
-            if opt["value"] in members:
-                result[f"_resolved_member_{opt['name']}"] = members[opt["value"]]
-        else:
-            result[opt["name"]] = opt["value"]
-    return result
-
-# ── Embed builder ────────────────────────────────────────────────────────────
-
-def _build_override_embed(
-    target_user_id: str,
-    target_username: str,
-    target_date: date,
-    current_state: dict,
-    confirmation: str | None = None,
-) -> Dict[str, Any]:
-    # Meal fields
-    fields = []
-    for meal_type in DEFAULT_MEAL_TYPES:
-        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
-        is_in = current_state["meals"].get(meal_type, True)
-        status_emoji = "✅" if is_in else "❌"
-        status_text = "Opted In" if is_in else "Opted Out"
-        fields.append({
-            "name": f"{display['emoji']} {display['label']}",
-            "value": f"{status_emoji} {status_text}",
-            "inline": True,
-        })
-
-    # Location field
-    loc = current_state["location"]
-    loc_display = LOCATION_DISPLAY.get(loc, {"label": loc.value, "emoji": "📍"})
-    fields.append({
-        "name": f"{loc_display['emoji']} Work Location",
-        "value": f"**{loc_display['label']}**",
-        "inline": True,
-    })
-
-    description_parts = [
-        f"👤 **Employee:** <@{target_user_id}>"
-        f" ({target_username})",
-        f"📅 **Date:** {format_date_display(target_date)}",
-    ]
-
-    if confirmation:
-        description_parts.append("")
-        description_parts.append(confirmation)
-
-    description_parts.append("")
-    description_parts.append("Use the buttons below to update this employee's records.")
-
-    embed = {
-        "title": "🔧 Override Update",
-        "description": "\n".join(description_parts),
-        "fields": fields,
-        "color": OVERRIDE_EMBED_COLOR,
-        "footer": {
-            "text": "Overrides are recorded for audit purposes"
-        },
-    }
-
-    return embed
-
-# ── Button builder ───────────────────────────────────────────────────────────
-
-def _build_override_buttons(
-    actor_id: str,
-    target_user_id: str,
-    target_date: date,
-    current_state: dict,
-) -> list[Dict[str, Any]]:
-    # Meal buttons (row 1)
-    meal_buttons: list[Dict[str, Any]] = []
-    for meal_type in DEFAULT_MEAL_TYPES:
-        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
-        is_in = current_state["meals"].get(meal_type, True)
-
-        # Button will toggle to the opposite state
-        new_state = "out" if is_in else "in"
-        custom_id = (
-            f"{OVERRIDE_MEAL_PREFIX}:{actor_id}:{target_user_id}"
-            f":{target_date.isoformat()}:{meal_type.value}:{new_state}"
-        )
-
-        if is_in:
-            style = BUTTON_SUCCESS
-            label = f"{display['emoji']} {display['label']} ✅"
-        else:
-            style = BUTTON_DANGER
-            label = f"{display['emoji']} {display['label']} ❌"
-
-        meal_buttons.append({
-            "type": BUTTON,
-            "style": style,
-            "label": label,
-            "custom_id": custom_id,
-        })
-
-    # Location buttons (row 2)
-    loc_buttons: list[Dict[str, Any]] = []
-    current_loc = current_state["location"]
-    for loc_type in (WorkLocationType.OFFICE, WorkLocationType.WFH):
-        loc_display = LOCATION_DISPLAY.get(loc_type, {"label": loc_type.value, "emoji": "📍"})
-        is_active = loc_type == current_loc
-        custom_id = (
-            f"{OVERRIDE_LOC_PREFIX}:{actor_id}:{target_user_id}"
-            f":{target_date.isoformat()}:{loc_type.value}"
-        )
-
-        if is_active:
-            style = BUTTON_SUCCESS
-            label = f"{loc_display['emoji']} {loc_display['label']} ✅"
-        else:
-            style = BUTTON_SECONDARY
-            label = f"{loc_display['emoji']} {loc_display['label']}"
-
-        loc_buttons.append({
-            "type": BUTTON,
-            "style": style,
-            "label": label,
-            "custom_id": custom_id,
-            "disabled": is_active,
-        })
-
-    rows = [
-        {"type": ACTION_ROW, "components": meal_buttons},
-        {"type": ACTION_ROW, "components": loc_buttons},
-    ]
-    return rows
-
-# ── Command handler ──────────────────────────────────────────────────────────
 
 def handle_override_update(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        options = _get_command_options(interaction)
+        options = interaction.options
         target_user_id = options.get("employee")
         date_str = options.get("date")
 
         if not target_user_id:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ Please select an employee to override.",
-                    "flags": 64,
-                },
-            }
+            return renderer.render_error("Please select an employee to override.")
 
         try:
             target_date = parse_date_option(date_str)
         except ValueError as e:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {e}", "flags": 64},
-            }
+            return renderer.render_error(str(e))
 
         is_valid, error_msg = validate_date_for_update(target_date)
         if not is_valid:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {error_msg}", "flags": 64},
-            }
+            return renderer.render_error(error_msg)
 
         target_team = None
-        resolved_member = options.get(f"_resolved_member_employee")
+        resolved_member = options.get("_resolved_member_employee")
         if resolved_member:
             target_roles = resolved_member.get("roles", [])
             target_team = extract_team_from_roles(target_roles)
 
-        # Team scope check
         allowed, scope_err = override_service.check_team_scope(
-            actor_role=user.role,
-            actor_team=user.team,
+            actor_role=interaction.user.role,
+            actor_team=interaction.user.team,
             target_team=target_team,
         )
         if not allowed:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": scope_err, "flags": 64},
-            }
+            return renderer.render_error(scope_err.lstrip("❌ "))
 
-        current_state = override_service.get_target_current_state(
-            target_user_id, target_date
-        )
-
-        resolved_user = options.get(f"_resolved_user_employee", {})
+        current_state = override_service.get_target_current_state(target_user_id, target_date)
+        resolved_user = options.get("_resolved_user_employee", {})
         target_username = resolved_user.get("username", target_user_id)
 
-        embed = _build_override_embed(
-            target_user_id, target_username, target_date, current_state
+        return renderer.render_override_status(
+            target_user_id, target_username, interaction.user.user_id, target_date, current_state,
+            target_team=target_team,
         )
-        components = _build_override_buttons(
-            user.discord_id, target_user_id, target_date, current_state
-        )
-
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-                "flags": 64,
-            },
-        }
 
     except Exception as e:
         logger.exception("Error handling override-update: %s", e)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while processing the override. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while processing the override. Please try again.")
 
-# ── Meal override button handler ─────────────────────────────────────────────
 
 def handle_override_meal(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        data = interaction.get("data", {})
-        custom_id = data.get("custom_id", "")
+        action_id = interaction.action_id or ""
 
-        parts = custom_id.split(":")
-        if len(parts) != 6 or parts[0] != OVERRIDE_MEAL_PREFIX:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": "❌ Invalid button interaction.", "flags": 64},
-            }
+        parts = action_id.split(":")
+        if len(parts) != 7 or parts[0] != OVERRIDE_MEAL_PREFIX:
+            return renderer.render_error("Invalid button interaction.")
 
-        _, actor_id, target_user_id, date_str, meal_type_str, state_str = parts
+        _, actor_id, target_user_id, date_str, meal_type_str, state_str, target_team_str = parts
 
         # Security: only the original actor can click
-        if user.discord_id != actor_id:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ Only the user who initiated the override can use these buttons.",
-                    "flags": 64,
-                },
-            }
+        if interaction.user.user_id != actor_id:
+            return renderer.render_error("Only the user who initiated the override can use these buttons.")
 
         target_date = date.fromisoformat(date_str)
 
         try:
             meal_type = MealType(meal_type_str)
         except ValueError:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ Unknown meal type: {meal_type_str}", "flags": 64},
-            }
+            return renderer.render_error(f"Unknown meal type: {meal_type_str}")
 
         is_participating = state_str == "in"
+        target_team = target_team_str or None
 
-        target_team = user.team  # fallback to actor's team for TL scope
+        # Re-validate team scope on every button click to prevent cross-team bypass
+        allowed, scope_err = override_service.check_team_scope(
+            actor_role=interaction.user.role,
+            actor_team=interaction.user.team,
+            target_team=target_team,
+        )
+        if not allowed:
+            return renderer.render_error(scope_err.lstrip("❌ "))
 
         success, result = override_service.override_meal(
             target_user_id=target_user_id,
             target_date=target_date,
             meal_type=meal_type,
             is_participating=is_participating,
-            actor_id=user.discord_id,
+            actor_id=interaction.user.user_id,
             target_team=target_team,
         )
 
         if not success:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {result}", "flags": 64},
-            }
+            return renderer.render_error(result)
 
-        # Refresh state and rebuild embed
-        current_state = override_service.get_target_current_state(
-            target_user_id, target_date
-        )
-
+        current_state = override_service.get_target_current_state(target_user_id, target_date)
         display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
         status_text = "✅ Opted In" if is_participating else "❌ Opted Out"
         confirmation = (
@@ -330,149 +123,126 @@ def handle_override_meal(
             f"for <@{target_user_id}>"
         )
 
-        embed = _build_override_embed(
-            target_user_id, target_user_id, target_date, current_state,
-            confirmation=confirmation,
+        status = renderer.render_override_status(
+            target_user_id, target_user_id, actor_id, target_date, current_state, confirmation,
+            target_team=target_team,
         )
-        components = _build_override_buttons(
-            user.discord_id, target_user_id, target_date, current_state
-        )
-
-        return {
-            "type": RESPONSE_UPDATE_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-            },
-        }
+        return renderer.render_update(status)
 
     except Exception as e:
         logger.exception("Error handling override meal: %s", e)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while processing the meal override. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while processing the meal override. Please try again.")
 
-# ── Location override button handler ─────────────────────────────────────────
 
 def handle_override_location(
-    interaction: Dict[str, Any], user: AuthenticatedUser
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
 ) -> Dict[str, Any]:
     try:
-        data = interaction.get("data", {})
-        custom_id = data.get("custom_id", "")
+        action_id = interaction.action_id or ""
 
-        parts = custom_id.split(":")
-        if len(parts) != 5 or parts[0] != OVERRIDE_LOC_PREFIX:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": "❌ Invalid button interaction.", "flags": 64},
-            }
+        parts = action_id.split(":")
+        if len(parts) != 6 or parts[0] != OVERRIDE_LOC_PREFIX:
+            return renderer.render_error("Invalid button interaction.")
 
-        _, actor_id, target_user_id, date_str, loc_str = parts
+        _, actor_id, target_user_id, date_str, loc_str, target_team_str = parts
 
-        if user.discord_id != actor_id:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {
-                    "content": "❌ Only the user who initiated the override can use these buttons.",
-                    "flags": 64,
-                },
-            }
+        if interaction.user.user_id != actor_id:
+            return renderer.render_error("Only the user who initiated the override can use these buttons.")
 
         target_date = date.fromisoformat(date_str)
 
         try:
             location = WorkLocationType(loc_str)
         except ValueError:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ Unknown location type: {loc_str}", "flags": 64},
-            }
+            return renderer.render_error(f"Unknown location type: {loc_str}")
 
-        target_team = user.team
+        target_team = target_team_str or None
+
+        # Re-validate team scope on every button click to prevent cross-team bypass
+        allowed, scope_err = override_service.check_team_scope(
+            actor_role=interaction.user.role,
+            actor_team=interaction.user.team,
+            target_team=target_team,
+        )
+        if not allowed:
+            return renderer.render_error(scope_err.lstrip("❌ "))
 
         success, result = override_service.override_location(
             target_user_id=target_user_id,
             target_date=target_date,
             location=location,
-            actor_id=user.discord_id,
+            actor_id=interaction.user.user_id,
             target_team=target_team,
         )
 
         if not success:
-            return {
-                "type": RESPONSE_CHANNEL_MESSAGE,
-                "data": {"content": f"❌ {result}", "flags": 64},
-            }
+            return renderer.render_error(result)
 
-        current_state = override_service.get_target_current_state(
-            target_user_id, target_date
-        )
-
+        current_state = override_service.get_target_current_state(target_user_id, target_date)
         loc_display = LOCATION_DISPLAY.get(location, {"label": location.value, "emoji": "📍"})
         confirmation = (
             f"✅ Updated **{loc_display['emoji']} Work Location** → "
             f"**{loc_display['label']}** for <@{target_user_id}>"
         )
 
-        embed = _build_override_embed(
-            target_user_id, target_user_id, target_date, current_state,
-            confirmation=confirmation,
+        status = renderer.render_override_status(
+            target_user_id, target_user_id, actor_id, target_date, current_state, confirmation,
+            target_team=target_team,
         )
-        components = _build_override_buttons(
-            user.discord_id, target_user_id, target_date, current_state
-        )
-
-        return {
-            "type": RESPONSE_UPDATE_MESSAGE,
-            "data": {
-                "embeds": [embed],
-                "components": components,
-            },
-        }
+        return renderer.render_update(status)
 
     except Exception as e:
         logger.exception("Error handling override location: %s", e)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {
-                "content": "❌ An error occurred while processing the location override. Please try again.",
-                "flags": 64,
-            },
-        }
+        return renderer.render_error("An error occurred while processing the location override. Please try again.")
 
 
-# ── Feature Lambda entry point (Issue #19) ───────────────────────────────────
+# ── Feature Lambda entry point ────────────────────────────────────────────────
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
-    interaction = event["interaction"]
-    user_dict = event["user"]
-    dispatch_type = event["dispatch_type"]
+    from src.adapters.discord.renderer import DiscordRenderer
+    from src.adapters.discord.ingress_adapter import _parse_command_options
+    from src.handlers.auth import AuthenticatedUser
 
+    renderer = DiscordRenderer()
+    user_dict = event["user"]
     user = AuthenticatedUser(
-        discord_id=user_dict["discord_id"],
+        user_id=user_dict["user_id"],
         username=user_dict["username"],
-        global_name=user_dict.get("global_name"),
+        display_name=user_dict.get("display_name"),
         role=UserRole(user_dict["role"]),
         team=user_dict.get("team"),
-        guild_id=user_dict["guild_id"],
-        discord_roles=user_dict.get("discord_roles", []),
+        space_id=user_dict.get("space_id", ""),
+        platform_roles=user_dict.get("platform_roles", []),
+        platform=user_dict.get("platform", "discord"),
+    )
+
+    raw_interaction = event.get("interaction", {})
+    dispatch_type = event["dispatch_type"]
+
+    if dispatch_type == "command":
+        options = event.get("options") or _parse_command_options(raw_interaction.get("data", {}))
+        action_id = None
+    else:
+        options = {}
+        action_id = event.get("action_id") or raw_interaction.get("data", {}).get("custom_id")
+
+    normalized = NormalizedInteraction(
+        platform=user_dict.get("platform", "discord"),
+        interaction_type=dispatch_type,
+        command_name=event.get("command_name"),
+        action_id=action_id,
+        options=options,
+        raw_body=raw_interaction,
+        user=user,
     )
 
     if dispatch_type == "command":
-        return handle_override_update(interaction, user)
+        return handle_override_update(normalized, renderer)
     else:
-        # Route to the correct component handler based on custom_id prefix
-        custom_id = interaction.get("data", {}).get("custom_id", "")
+        custom_id = action_id or ""
         if custom_id.startswith(OVERRIDE_MEAL_PREFIX):
-            return handle_override_meal(interaction, user)
+            return handle_override_meal(normalized, renderer)
         if custom_id.startswith(OVERRIDE_LOC_PREFIX):
-            return handle_override_location(interaction, user)
-        return {
-            "type": RESPONSE_CHANNEL_MESSAGE,
-            "data": {"content": "❌ Unknown override component.", "flags": 64},
-        }
+            return handle_override_location(normalized, renderer)
+        return renderer.render_error("Unknown override component.")

--- a/Task2_mhp_discord-bot/backend/src/models.py
+++ b/Task2_mhp_discord-bot/backend/src/models.py
@@ -24,7 +24,7 @@ class DayType(str, Enum):
 # ── User ──────────────────────────────────────────────────────────────────────
 
 class User(BaseModel):
-    discord_id: str
+    user_id: str  # platform-agnostic opaque ID (Discord snowflake, Google Chat "users/..." etc.)
     name: str
     email: Optional[str] = None
     role: UserRole = UserRole.EMPLOYEE
@@ -55,12 +55,12 @@ class Team(BaseModel):
 # ── Meal Participation ────────────────────────────────────────────────────────
 
 class MealParticipation(BaseModel):
-    user_id: str  # discord_id
+    user_id: str  # platform-agnostic user identifier
     meal_type: MealType
     date: date
     is_participating: bool = True
-    team: Optional[str] = None  # stamped from Discord role at write time
-    updated_by: Optional[str] = None  # discord_id of actor
+    team: Optional[str] = None  # stamped from role at write time
+    updated_by: Optional[str] = None  # user_id of actor
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     reason: Optional[str] = None
     gsi1_pk: Optional[str] = None  # "DATE#<YYYY-MM-DD>"
@@ -69,10 +69,10 @@ class MealParticipation(BaseModel):
 # ── Work Location ─────────────────────────────────────────────────────────────
 
 class WorkLocation(BaseModel):
-    user_id: str  # discord_id
+    user_id: str  # platform-agnostic user identifier
     date: date
     location: WorkLocationType = WorkLocationType.OFFICE
-    team: Optional[str] = None  # stamped from Discord role at write time
+    team: Optional[str] = None  # stamped from role at write time
     updated_by: Optional[str] = None
     updated_at: datetime = Field(default_factory=datetime.utcnow)
     gsi1_pk: Optional[str] = None  # "DATE#<YYYY-MM-DD>"

--- a/Task2_mhp_discord-bot/backend/src/services/discord_helpers.py
+++ b/Task2_mhp_discord-bot/backend/src/services/discord_helpers.py
@@ -1,40 +1,6 @@
-import json
-import logging
-from typing import Optional
-
-logger = logging.getLogger(__name__)
-
-# In-memory cache — loaded once per Lambda cold start
-_team_role_map: dict | None = None
-
-
-def get_team_role_map() -> dict:
-    global _team_role_map
-    if _team_role_map is None:
-        # Import here to avoid circular dependency (storage -> config -> helpers)
-        from src.storage.dynamodb import storage
-        policy = storage.get_policy("team_role_map")
-        if policy:
-            try:
-                _team_role_map = json.loads(policy.value)
-            except (json.JSONDecodeError, TypeError):
-                logger.warning("Invalid team_role_map policy value, defaulting to empty")
-                _team_role_map = {}
-        else:
-            logger.info("No team_role_map policy found, defaulting to empty")
-            _team_role_map = {}
-    return _team_role_map
-
-
-def invalidate_team_role_cache() -> None:
-    global _team_role_map
-    _team_role_map = None
-
-
-def extract_team_from_roles(member_roles: list[str]) -> Optional[str]:
-    team_role_map = get_team_role_map()
-
-    for role_id in member_roles:
-        if role_id in team_role_map:
-            return team_role_map[role_id]
-    return None
+# Backward-compatibility shim — canonical location is now team_helpers.py
+from src.services.team_helpers import (  # noqa: F401
+    get_team_role_map,
+    invalidate_team_role_cache,
+    extract_team_from_roles,
+)

--- a/Task2_mhp_discord-bot/backend/src/services/location_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/location_service.py
@@ -3,9 +3,10 @@ import logging
 from datetime import date, datetime
 
 from src.config import settings
-from src.models import WorkLocation, WorkLocationType
+from src.models import MealParticipation, WorkLocation, WorkLocationType
 from src.storage.dynamodb import DynamoDBStorage, storage as default_storage
 from src.utils import validate_date_for_update, DHAKA_UTC_OFFSET
+from src.services.meal_service import DEFAULT_MEAL_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,22 @@ class LocationService:
         )
 
         self.storage.put_location(record)
+
+        if location == WorkLocationType.WFH:
+            for meal_type in DEFAULT_MEAL_TYPES:
+                self.storage.put_meal(MealParticipation(
+                    user_id=discord_id,
+                    meal_type=meal_type,
+                    date=target_date,
+                    is_participating=False,
+                    team=team,
+                    updated_by=updated_by or discord_id,
+                    updated_at=now,
+                ))
+            logger.info(
+                "WFH set: auto opted-out of all meals for user=%s, date=%s",
+                discord_id, target_date,
+            )
 
         logger.info(
             "Location set: user=%s, date=%s, location=%s",

--- a/Task2_mhp_discord-bot/backend/src/services/team_helpers.py
+++ b/Task2_mhp_discord-bot/backend/src/services/team_helpers.py
@@ -1,0 +1,38 @@
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_team_role_map: dict | None = None
+
+
+def get_team_role_map() -> dict:
+    global _team_role_map
+    if _team_role_map is None:
+        from src.storage.dynamodb import storage
+        policy = storage.get_policy("team_role_map")
+        if policy:
+            try:
+                _team_role_map = json.loads(policy.value)
+            except (json.JSONDecodeError, TypeError):
+                logger.warning("Invalid team_role_map policy value, defaulting to empty")
+                _team_role_map = {}
+        else:
+            logger.info("No team_role_map policy found, defaulting to empty")
+            _team_role_map = {}
+    return _team_role_map
+
+
+def invalidate_team_role_cache() -> None:
+    global _team_role_map
+    _team_role_map = None
+
+
+def extract_team_from_roles(member_roles: list[str]) -> Optional[str]:
+    team_role_map = get_team_role_map()
+
+    for role_id in member_roles:
+        if role_id in team_role_map:
+            return team_role_map[role_id]
+    return None

--- a/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
+++ b/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
@@ -57,9 +57,9 @@ class DynamoDBStorage:
 
     def put_user(self, user: User) -> None:
         self.table.put_item(Item={
-            "PK": f"USER#{user.discord_id}",
+            "PK": f"USER#{user.user_id}",
             "SK": "PROFILE",
-            "discord_id": user.discord_id,
+            "user_id": user.user_id,
             "name": user.name,
             "email": user.email,
             "role": user.role.value,
@@ -67,18 +67,25 @@ class DynamoDBStorage:
             "is_active": user.is_active,
             "created_at": user.created_at.isoformat(),
             "GSI2PK": "USER",
-            "GSI2SK": f"{user.created_at.isoformat()}#{user.discord_id}",
+            "GSI2SK": f"{user.created_at.isoformat()}#{user.user_id}",
         })
-        # Write external identity lookup for discord
-        self.put_identity(ExternalIdentity(
-            provider="discord",
-            external_id=user.discord_id,
-            user_id=user.discord_id,
-        ))
 
     def get_user_team(self, discord_id: str) -> Optional[str]:
         user = self.get_user(discord_id)
         return user.team if user else None
+
+    def get_canonical_user_id(self, provider: str, external_id: str) -> Optional[str]:
+        try:
+            resp = self.table.get_item(
+                Key={
+                    "PK": f"IDENT#{provider}#{external_id}",
+                    "SK": f"IDENT#{provider}#{external_id}",
+                }
+            )
+            item = resp.get("Item")
+            return item["user_id"] if item else None
+        except ClientError:
+            return None
 
     def get_user_by_identity(self, provider: str, external_id: str) -> Optional[User]:
         try:
@@ -425,7 +432,7 @@ class DynamoDBStorage:
 
 def _parse_user_item(item: dict) -> User:
     return User(
-        discord_id=item["discord_id"],
+        user_id=item.get("user_id") or item.get("discord_id", ""),  # backwards compat
         name=item["name"],
         email=item.get("email"),
         role=UserRole(item.get("role", "employee")),

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -95,7 +95,7 @@ def validate_date_for_update(target_date: date) -> tuple[bool, str | None]:
 
 def parse_date_option(date_str: str | None) -> date:
     if not date_str:
-        return get_dhaka_today()
+        return get_dhaka_today() + timedelta(days=1)
 
     try:
         return date.fromisoformat(date_str)


### PR DESCRIPTION
## Related Issues
* Fixes #47

## Summary
Wires the channel adapter architecture into all business logic handlers, adds the Google Chat ingress Lambda, implements the `/link-identity` command for cross-platform identity mapping, and fixes three bugs: default date defaulting to tomorrow, WFH auto opt-out of meals, and team scope bypass on override button clicks.

## Dependencies

- PR #56 

## Changes
- Refactor `handlers/` — all handlers now accept `NormalizedInteraction` + `UIRenderer` instead of raw Discord dicts
- Add `handlers/google_chat_ingress.py` — Google Chat Lambda entry point with async REST API message posting and synchronous button click responses
- Add `handlers/link_handler.py` — `/link-identity` command; admins can link anyone, employees/TLs can only link themselves
- Add `storage/dynamodb.py` — `get_canonical_user_id()` for IDENT# lookups and `put_identity()` for writing identity pairs
- Add `services/team_helpers.py` — extracted team role resolution helpers
- Fix `utils.py` — `parse_date_option(None)` now defaults to tomorrow instead of today
- Fix `services/location_service.py` — setting WFH auto opts-out all meals; reverting to Office does not restore them
- Fix `handlers/override_handler.py` — team scope re-validated on every override button click (Bug 2); `target_team` encoded in action_id
- Add `requirements-dev.txt` — separate dev/test dependencies from Lambda runtime dependencies
- Update `config.py` — add `GOOGLE_CHAT_AUDIENCE`, `GOOGLE_CHAT_ADMIN_EMAILS`, `GOOGLE_CHAT_TEAM_LEAD_EMAILS`, `GOOGLE_CHAT_SERVICE_ACCOUNT_JSON`

## Context
Handlers were previously Discord-only and returned raw Discord response dicts. They now return renderer-agnostic responses via the `UIRenderer` interface introduced in the adapter layer. The Google Chat ingress uses async message posting (via service account + Chat REST API) for slash commands, and synchronous HTTP responses for button clicks, matching Google Chat's API requirements discovered during integration testing.

## How to Test (if applicable)
For live integration testing against the deployed Lambdas:

1. **Discord ingress Lambda:** [link to trainee-2026-niloy-mhp-ingress Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-ingress?tab=code)
   - Use `/meal-update` → verify meal status card for tomorrow appears
   - Use `/work-location` → verify location card appears
   - Set location to WFH → verify all meals auto opt-out
   - Use `/override-update @employee` as team lead → verify only own-team employees shown

2. **Google Chat ingress Lambda:** [link to trainee-2026-niloy-mhp-gchat-ingress Lambda](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-gchat-ingress?tab=code)
   - Use `/meal-update` in Google Chat → verify message posted to space
   - Use `/work-location` → verify location message posted
   - Click a toggle button on a card → verify updated card returned synchronously

3. **Link identity** — in either platform, use `/link-identity` to map a Discord user to a Google Chat email, then verify the same meal record appears when checking from both platforms

## Checklist (select options which are applicable)
- [x] Code builds successfully
- [ ] Tests added or updated
- [x] Documentation updated/added
- [x] No breaking changes

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
