### PR TITLE
PR 27: Implement the headcount summary slash command for Issue #2.6

### DIFF
--- a/Task2_mhp_discord-bot/.gitignore
+++ b/Task2_mhp_discord-bot/.gitignore
@@ -36,6 +36,8 @@ backend/deployment.zip
 # SAM build artifacts
 .aws-sam/
 samconfig.toml
+layer/
+Makefile
 
 # Data files (JSON storage & SQLite)
 backend/data/*.json

--- a/Task2_mhp_discord-bot/backend/src/adapters/base.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/base.py
@@ -69,6 +69,26 @@ class UIRenderer(ABC):
     ) -> Dict[str, Any]:
         """Return a response payload for the override view."""
 
+    # ── Headcount / Summary ───────────────────────────────────────────────────
+
+    @abstractmethod
+    def render_team_summary(
+        self,
+        target_date: date,
+        team_name: str,
+        summary: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Return a response payload showing team-level headcount summary."""
+
+    @abstractmethod
+    def render_headcount_summary(
+        self,
+        target_date: date,
+        summary: Dict[str, Any],
+        team_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return a response payload showing full headcount summary with optional team breakdown."""
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     @abstractmethod

--- a/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
@@ -94,6 +94,32 @@ class DiscordRenderer(UIRenderer):
             },
         }
 
+    # ── Headcount / Summary ───────────────────────────────────────────────────
+
+    def render_team_summary(
+        self,
+        target_date: date,
+        team_name: str,
+        summary: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        embed = _build_team_summary_embed(target_date, team_name, summary)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"embeds": [embed], "flags": EPHEMERAL_FLAG},
+        }
+
+    def render_headcount_summary(
+        self,
+        target_date: date,
+        summary: Dict[str, Any],
+        team_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        embed = _build_headcount_summary_embed(target_date, summary, team_filter)
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"embeds": [embed], "flags": EPHEMERAL_FLAG},
+        }
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     def render_success(self, message: str) -> Dict[str, Any]:
@@ -251,6 +277,102 @@ def _build_override_embed(
         "fields": fields,
         "color": OVERRIDE_EMBED_COLOR,
         "footer": {"text": "Overrides are recorded for audit purposes"},
+    }
+
+
+def _build_team_summary_embed(
+    target_date: date,
+    team_name: str,
+    summary: Dict[str, Any],
+) -> Dict[str, Any]:
+    special_day = summary.get("special_day")
+    total = summary.get("total_responding", 0)
+
+    parts = [f"📅 **{format_date_display(target_date)}**"]
+    if special_day:
+        parts.append(f"⚠️ *{special_day.day_type.value}*{f' — {special_day.note}' if special_day.note else ''}")
+    parts.append(f"👥 **{total}** employee(s) have submitted data")
+
+    fields = []
+    for meal_type, counts in summary.get("meal_counts", {}).items():
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        opted_in = counts["opted_in"]
+        opted_out = counts["opted_out"]
+        fields.append({
+            "name": f"{display['emoji']} {display['label']}",
+            "value": f"✅ {opted_in} opted in  •  ❌ {opted_out} opted out",
+            "inline": True,
+        })
+
+    loc = summary.get("location_count", {})
+    fields.append({
+        "name": "📍 Work Location",
+        "value": f"🏢 {loc.get('office', 0)} Office  •  🏠 {loc.get('wfh', 0)} WFH",
+        "inline": True,
+    })
+
+    return {
+        "title": f"📊 Team Summary — {team_name}",
+        "description": "\n".join(parts),
+        "fields": fields,
+        "color": 0x5865F2,
+        "footer": {"text": "Showing employees who have submitted data for this date"},
+    }
+
+
+def _build_headcount_summary_embed(
+    target_date: date,
+    summary: Dict[str, Any],
+    team_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+    special_day = summary.get("special_day")
+    total = summary.get("total_responding", 0)
+    title = f"📊 Headcount Summary{f' — {team_filter}' if team_filter else ''}"
+
+    parts = [f"📅 **{format_date_display(target_date)}**"]
+    if special_day:
+        parts.append(f"⚠️ *{special_day.day_type.value}*{f' — {special_day.note}' if special_day.note else ''}")
+    parts.append(f"👥 **{total}** employee(s) total")
+
+    fields = []
+    for meal_type, counts in summary.get("meal_counts", {}).items():
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        fields.append({
+            "name": f"{display['emoji']} {display['label']}",
+            "value": f"✅ {counts['opted_in']} opted in  •  ❌ {counts['opted_out']} opted out",
+            "inline": True,
+        })
+
+    loc = summary.get("location_count", {})
+    fields.append({
+        "name": "📍 Work Location",
+        "value": f"🏢 {loc.get('office', 0)} Office  •  🏠 {loc.get('wfh', 0)} WFH",
+        "inline": True,
+    })
+
+    # Per-team breakdown (admin all-teams view)
+    team_breakdown = summary.get("team_breakdown", {})
+    if team_breakdown:
+        fields.append({"name": "\u200b", "value": "**Team Breakdown**", "inline": False})
+        for team, tdata in team_breakdown.items():
+            meal_lines = []
+            for meal_type, counts in tdata.get("meal_counts", {}).items():
+                display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+                meal_lines.append(f"{display['emoji']} ✅{counts['opted_in']}/❌{counts['opted_out']}")
+            tloc = tdata.get("location_count", {})
+            loc_line = f"🏢{tloc.get('office', 0)} 🏠{tloc.get('wfh', 0)}"
+            fields.append({
+                "name": f"🏷️ {team} ({tdata.get('total_responding', 0)})",
+                "value": "  ".join(meal_lines) + f"  {loc_line}",
+                "inline": False,
+            })
+
+    return {
+        "title": title,
+        "description": "\n".join(parts),
+        "fields": fields,
+        "color": 0x5865F2,
+        "footer": {"text": "Showing employees who have submitted data for this date"},
     }
 
 

--- a/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
@@ -174,6 +174,44 @@ class GoogleChatRenderer(UIRenderer):
             ],
         )
 
+    # ── Headcount / Summary ───────────────────────────────────────────────────
+
+    def render_team_summary(
+        self,
+        target_date: date,
+        team_name: str,
+        summary: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        widgets = _build_summary_widgets(summary)
+        return _wrap_card(
+            card_id="team_summary",
+            title=f"📊 Team Summary — {team_name}",
+            subtitle=format_date_display(target_date),
+            sections=[{"widgets": widgets}],
+        )
+
+    def render_headcount_summary(
+        self,
+        target_date: date,
+        summary: Dict[str, Any],
+        team_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        title = f"📊 Headcount Summary{f' — {team_filter}' if team_filter else ''}"
+        sections = [{"widgets": _build_summary_widgets(summary)}]
+
+        for team, tdata in summary.get("team_breakdown", {}).items():
+            sections.append({
+                "header": team,
+                "widgets": _build_summary_widgets(tdata),
+            })
+
+        return _wrap_card(
+            card_id="headcount_summary",
+            title=title,
+            subtitle=format_date_display(target_date),
+            sections=sections,
+        )
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     def render_success(self, message: str) -> Dict[str, Any]:
@@ -228,6 +266,39 @@ def _render_text(text: str) -> Dict[str, Any]:
             }
         }
     }
+
+
+def _build_summary_widgets(summary: Dict[str, Any]) -> list:
+    widgets = []
+
+    special_day = summary.get("special_day")
+    if special_day:
+        note = f" — {special_day.note}" if special_day.note else ""
+        widgets.append({"textParagraph": {"text": f"⚠️ {special_day.day_type.value}{note}"}})
+
+    total = summary.get("total_responding", 0)
+    widgets.append({"textParagraph": {"text": f"👥 <b>{total}</b> employee(s) responded"}})
+
+    for meal_type, counts in summary.get("meal_counts", {}).items():
+        display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+        opted_in = counts["opted_in"]
+        opted_out = counts["opted_out"]
+        widgets.append({
+            "decoratedText": {
+                "text": f"{display['emoji']} {display['label']}",
+                "bottomLabel": f"✅ {opted_in} opted in  •  ❌ {opted_out} opted out",
+            }
+        })
+
+    loc = summary.get("location_count", {})
+    widgets.append({
+        "decoratedText": {
+            "text": "📍 Work Location",
+            "bottomLabel": f"🏢 {loc.get('office', 0)} Office  •  🏠 {loc.get('wfh', 0)} WFH",
+        }
+    })
+
+    return widgets
 
 
 def _green() -> Dict[str, Any]:

--- a/Task2_mhp_discord-bot/backend/src/handlers/dispatcher.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/dispatcher.py
@@ -9,9 +9,11 @@ logger = logging.getLogger(__name__)
 
 # ── Command → Lambda function name ───────────────────────────────────────────
 COMMAND_FUNCTION_MAP: Dict[str, str] = {
-    "meal-update":     os.getenv("MEAL_FUNCTION_NAME", ""),
-    "work-location":   os.getenv("LOCATION_FUNCTION_NAME", ""),
-    "override-update": os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+    "meal-update":       os.getenv("MEAL_FUNCTION_NAME", ""),
+    "work-location":     os.getenv("LOCATION_FUNCTION_NAME", ""),
+    "override-update":   os.getenv("OVERRIDE_FUNCTION_NAME", ""),
+    "team-summary":      os.getenv("HEADCOUNT_FUNCTION_NAME", ""),
+    "headcount-summary": os.getenv("HEADCOUNT_FUNCTION_NAME", ""),
 }
 
 # ── Component custom_id prefix → Lambda function name ────────────────────────

--- a/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
@@ -28,6 +28,7 @@ from src.handlers.override_handler import (
     OVERRIDE_LOC_PREFIX,
 )
 from src.handlers.link_handler import handle_link_identity
+from src.handlers.headcount_handler import handle_team_summary, handle_headcount_summary
 from src.config import settings
 
 logger = logging.getLogger(__name__)
@@ -110,6 +111,10 @@ def _route_command(normalized) -> Dict[str, Any]:
         return handle_override_update(normalized, _renderer)
     if cmd == "link-identity":
         return handle_link_identity(normalized, _renderer)
+    if cmd == "team-summary":
+        return handle_team_summary(normalized, _renderer)
+    if cmd == "headcount-summary":
+        return handle_headcount_summary(normalized, _renderer)
     return _renderer.render_error(f"Unknown command: `{cmd}`")
 
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/headcount_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/headcount_handler.py
@@ -1,0 +1,108 @@
+# Handles /team-summary and /headcount-summary slash commands
+import logging
+from datetime import date
+from typing import Any, Dict
+
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
+from src.models import UserRole
+from src.services.headcount_service import headcount_service
+from src.utils import get_dhaka_today
+
+logger = logging.getLogger(__name__)
+
+
+def handle_team_summary(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    try:
+        date_str = interaction.options.get("date")
+        if date_str:
+            try:
+                target_date = date.fromisoformat(date_str)
+            except ValueError:
+                return renderer.render_error(
+                    f"Invalid date format: '{date_str}'. Use YYYY-MM-DD."
+                )
+        else:
+            target_date = get_dhaka_today()
+
+        # Team leads see their own team; admins can optionally specify a different team
+        team_name = interaction.options.get("team") or interaction.user.team
+        if not team_name:
+            return renderer.render_error(
+                "You are not assigned to a team. Ask an admin to assign you to a team."
+            )
+
+        summary = headcount_service.get_team_summary(target_date, team_name)
+        return renderer.render_team_summary(target_date, team_name, summary)
+
+    except Exception as e:
+        logger.exception(f"Error handling team-summary: {e}")
+        return renderer.render_error(
+            "An error occurred while fetching the team summary. Please try again."
+        )
+
+
+def handle_headcount_summary(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    try:
+        date_str = interaction.options.get("date")
+        if date_str:
+            try:
+                target_date = date.fromisoformat(date_str)
+            except ValueError:
+                return renderer.render_error(
+                    f"Invalid date format: '{date_str}'. Use YYYY-MM-DD."
+                )
+        else:
+            target_date = get_dhaka_today()
+
+        team_filter = interaction.options.get("team") or None
+
+        summary = headcount_service.get_headcount_summary(target_date, team_filter)
+        return renderer.render_headcount_summary(target_date, summary, team_filter)
+
+    except Exception as e:
+        logger.exception(f"Error handling headcount-summary: {e}")
+        return renderer.render_error(
+            "An error occurred while fetching the headcount summary. Please try again."
+        )
+
+
+# ── Feature Lambda entry point ────────────────────────────────────────────────
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    from src.adapters.discord.renderer import DiscordRenderer
+    from src.handlers.auth import AuthenticatedUser
+
+    renderer = DiscordRenderer()
+    user_dict = event["user"]
+    user = AuthenticatedUser(
+        user_id=user_dict["user_id"],
+        username=user_dict["username"],
+        display_name=user_dict.get("display_name"),
+        role=UserRole(user_dict["role"]),
+        team=user_dict.get("team"),
+        space_id=user_dict.get("space_id", ""),
+        platform_roles=user_dict.get("platform_roles", []),
+        platform=user_dict.get("platform", "discord"),
+    )
+
+    normalized = NormalizedInteraction(
+        platform=user_dict.get("platform", "discord"),
+        interaction_type=event["dispatch_type"],
+        command_name=event.get("command_name"),
+        action_id=None,
+        options=event.get("options", {}),
+        raw_body=event.get("interaction", {}),
+        user=user,
+    )
+
+    cmd = event.get("command_name", "")
+    if cmd == "team-summary":
+        return handle_team_summary(normalized, renderer)
+    return handle_headcount_summary(normalized, renderer)

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -25,6 +25,7 @@ from src.handlers.override_handler import (
     OVERRIDE_LOC_PREFIX,
 )
 from src.handlers.link_handler import handle_link_identity
+from src.handlers.headcount_handler import handle_team_summary, handle_headcount_summary
 from src.handlers import dispatcher
 from src.config import settings
 
@@ -79,6 +80,10 @@ def _route_inprocess(normalized, interaction_type: int) -> Dict[str, Any]:
             return handle_override_update(normalized, _renderer)
         if cmd == "link-identity":
             return handle_link_identity(normalized, _renderer)
+        if cmd == "team-summary":
+            return handle_team_summary(normalized, _renderer)
+        if cmd == "headcount-summary":
+            return handle_headcount_summary(normalized, _renderer)
         return {
             "type": RESPONSE_CHANNEL_MESSAGE,
             "data": {

--- a/Task2_mhp_discord-bot/backend/src/services/headcount_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/headcount_service.py
@@ -1,0 +1,109 @@
+# Business logic for headcount and team summary aggregation
+import logging
+from collections import defaultdict
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from src.models import MealType, WorkLocationType
+from src.services.meal_service import DEFAULT_MEAL_TYPES
+from src.storage.dynamodb import DynamoDBStorage, storage as default_storage
+
+logger = logging.getLogger(__name__)
+
+
+class HeadcountService:
+
+    def __init__(self, storage: DynamoDBStorage = None):
+        self.storage = storage or default_storage
+
+    def get_team_summary(self, target_date: date, team_name: str) -> Dict[str, Any]:
+        """Aggregate meal + location data for a single team on a given date."""
+        special_day = self.storage.get_special_day(target_date)
+        meals = self.storage.get_meals_for_date_and_team(target_date, team_name)
+        locations = self.storage.get_locations_for_date_and_team(target_date, team_name)
+
+        user_ids = set(m.user_id for m in meals) | set(l.user_id for l in locations)
+
+        return {
+            "date": target_date,
+            "team_name": team_name,
+            "special_day": special_day,
+            "meal_counts": _aggregate_meals(meals),
+            "location_count": _aggregate_locations(locations),
+            "total_responding": len(user_ids),
+        }
+
+    def get_headcount_summary(
+        self, target_date: date, team_filter: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Aggregate meal + location data across all (or one) team(s) on a given date."""
+        special_day = self.storage.get_special_day(target_date)
+
+        if team_filter:
+            meals = self.storage.get_meals_for_date_and_team(target_date, team_filter)
+            locations = self.storage.get_locations_for_date_and_team(target_date, team_filter)
+        else:
+            meals = self.storage.get_meals_for_date(target_date)
+            locations = self.storage.get_locations_for_date(target_date)
+
+        user_ids = set(m.user_id for m in meals) | set(l.user_id for l in locations)
+
+        # Build per-team breakdown only when showing all teams
+        team_breakdown: Dict[str, Any] = {}
+        if not team_filter:
+            team_meals: Dict[str, list] = defaultdict(list)
+            team_locs: Dict[str, list] = defaultdict(list)
+
+            for m in meals:
+                if m.team:
+                    team_meals[m.team].append(m)
+            for loc in locations:
+                if loc.team:
+                    team_locs[loc.team].append(loc)
+
+            for team in sorted(set(team_meals.keys()) | set(team_locs.keys())):
+                t_user_ids = (
+                    set(m.user_id for m in team_meals[team]) |
+                    set(l.user_id for l in team_locs[team])
+                )
+                team_breakdown[team] = {
+                    "meal_counts": _aggregate_meals(team_meals[team]),
+                    "location_count": _aggregate_locations(team_locs[team]),
+                    "total_responding": len(t_user_ids),
+                }
+
+        return {
+            "date": target_date,
+            "special_day": special_day,
+            "meal_counts": _aggregate_meals(meals),
+            "location_count": _aggregate_locations(locations),
+            "total_responding": len(user_ids),
+            "team_breakdown": team_breakdown,
+            "team_filter": team_filter,
+        }
+
+
+# ── Private helpers ───────────────────────────────────────────────────────────
+
+def _aggregate_meals(meals: List) -> Dict[MealType, Dict[str, int]]:
+    counts: Dict[MealType, Dict[str, int]] = {
+        mt: {"opted_in": 0, "opted_out": 0} for mt in DEFAULT_MEAL_TYPES
+    }
+    for meal in meals:
+        if meal.meal_type in counts:
+            key = "opted_in" if meal.is_participating else "opted_out"
+            counts[meal.meal_type][key] += 1
+    return counts
+
+
+def _aggregate_locations(locations: List) -> Dict[str, int]:
+    result = {"office": 0, "wfh": 0}
+    for loc in locations:
+        if loc.location == WorkLocationType.OFFICE:
+            result["office"] += 1
+        elif loc.location == WorkLocationType.WFH:
+            result["wfh"] += 1
+    return result
+
+
+headcount_service = HeadcountService()


### PR DESCRIPTION
## Related Issues
* Fixes #25  
* Related: #48 #49 #50 

## Summary
This PR implements Issue 2.6 headcount reporting support across both Discord and Google Chat adapters, and wires summary commands into the ingress and dispatcher flow.

It adds:
- Team-level summary handling for team-summary
- Admin headcount summary handling for headcount-summary
- Shared aggregation service for meals and work locations
- Renderer support in both Discord and Google Chat for summary views
- Command routing updates for summary commands in multi-lambda dispatch paths

## Dependencies
- none needed

## Changes
- Added a new headcount handler with team-summary and headcount-summary command logic, plus a feature-lambda entry point.
- Added a new headcount service that aggregates:
  - meal opted-in and opted-out counts
  - office and WFH location counts
  - total responding users
  - optional per-team breakdown for admin all-team views
  - special-day context in summary output
- Extended adapter renderer interface with:
  - render_team_summary
  - render_headcount_summary
- Implemented Discord renderer summary embeds, including:
  - date and special-day context
  - meal counts
  - location split
  - optional team breakdown section
- Implemented Google Chat renderer summary cards with equivalent content.
- Updated ingress routing (Discord + Google Chat) to support:
  - team-summary
  - headcount-summary
- Updated dispatcher command-function mapping so summary commands can target the headcount lambda.
- Updated gitignore to exclude layer and Makefile artifacts.

## Context
Issue 6 requires report-ready retrieval for Team Leads and Admins. Before this PR, authorization keys existed for team-summary and headcount-summary, but command handling and rendering were missing. This PR closes that functional gap and aligns summary behavior across platforms.

## How to Test (if applicable)
1. Register or confirm slash commands include team-summary and headcount-summary.
2. Seed test data for at least two teams with meal and location entries on the same date.
3. As Team Lead:
   - run team-summary with and without date
   - verify only own team summary appears
4. As Admin:
   - run headcount-summary without team filter and verify team breakdown is present
   - run headcount-summary with team filter and verify scoped output

[Headcount Summary Lambda Link](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-headcount?tab=code)

## Checklist (select options which are applicable)
- [x] Code builds successfully
- [ ] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes