### PR TITLE
PR 28: Implement Issue #2.8 Team-based Visibility

### DIFF
--- a/Task2_mhp_discord-bot/backend/src/adapters/base.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/base.py
@@ -39,6 +39,7 @@ class UIRenderer(ABC):
         target_date: date,
         meals: Dict["MealType", Optional["MealParticipation"]],
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a response payload showing meal participation status."""
 
@@ -51,6 +52,7 @@ class UIRenderer(ABC):
         target_date: date,
         current: "WorkLocationType",
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a response payload showing work location."""
 

--- a/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
@@ -37,8 +37,9 @@ class DiscordRenderer(UIRenderer):
         target_date: date,
         meals: Dict[MealType, Optional[MealParticipation]],
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
-        embed = _build_meal_embed(user_id, target_date, meals, confirmation)
+        embed = _build_meal_embed(user_id, target_date, meals, confirmation, team=team)
         components = _build_meal_buttons(user_id, target_date, meals)
         return {
             "type": RESPONSE_CHANNEL_MESSAGE,
@@ -57,8 +58,9 @@ class DiscordRenderer(UIRenderer):
         target_date: date,
         current: WorkLocationType,
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
-        embed = _build_location_embed(user_id, target_date, current, confirmation)
+        embed = _build_location_embed(user_id, target_date, current, confirmation, team=team)
         components = _build_location_buttons(user_id, target_date, current)
         return {
             "type": RESPONSE_CHANNEL_MESSAGE,
@@ -148,6 +150,7 @@ def _build_meal_embed(
     target_date: date,
     meals: Dict[MealType, Optional[MealParticipation]],
     confirmation: Optional[str] = None,
+    team: Optional[str] = None,
 ) -> Dict[str, Any]:
     fields = []
     for meal_type, record in meals.items():
@@ -167,12 +170,16 @@ def _build_meal_embed(
     else:
         description = f"{date_line}\n\nClick a button below to toggle your participation for each meal."
 
+    footer_text = "Default: Opted In for all meals • Toggle to change"
+    if team:
+        footer_text = f"🏷️ Team: {team}  •  {footer_text}"
+
     return {
         "title": "🍽️ Meal Participation",
         "description": description,
         "fields": fields,
         "color": 0x5865F2,  # Discord blurple
-        "footer": {"text": "Default: Opted In for all meals • Toggle to change"},
+        "footer": {"text": footer_text},
     }
 
 
@@ -201,6 +208,7 @@ def _build_location_embed(
     target_date: date,
     current: WorkLocationType,
     confirmation: Optional[str] = None,
+    team: Optional[str] = None,
 ) -> Dict[str, Any]:
     display = LOCATION_DISPLAY.get(current, {"label": current.value, "emoji": "📍"})
     status_line = f"{display['emoji']} **{display['label']}**"
@@ -210,11 +218,15 @@ def _build_location_embed(
         parts += [confirmation, ""]
     parts += [f"Current location: {status_line}", "", "Click a button below to change your work location."]
 
+    footer_text = "Default: Office • WFH days count toward monthly cap"
+    if team:
+        footer_text = f"🏷️ Team: {team}  •  {footer_text}"
+
     return {
         "title": "📍 Work Location",
         "description": "\n".join(parts),
         "color": 0x57F287 if current == WorkLocationType.OFFICE else 0xFEE75C,
-        "footer": {"text": "Default: Office • WFH days count toward monthly cap"},
+        "footer": {"text": footer_text},
     }
 
 
@@ -311,12 +323,41 @@ def _build_team_summary_embed(
         "inline": True,
     })
 
+    # Per-member breakdown
+    members = summary.get("members", [])
+    if members:
+        fields.append({"name": "\u200b", "value": "**👤 Member Details**", "inline": False})
+        for member in members[:25]:  # Discord embed field limit
+            name = member.get("display_name") or member.get("user_id", "Unknown")
+            meal_parts = []
+            for meal_type, is_in in member.get("meals", {}).items():
+                display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+                meal_parts.append(f"{display['emoji']}{'✅' if is_in else '❌'}")
+            loc_val = member.get("location")
+            if loc_val:
+                loc_display = LOCATION_DISPLAY.get(loc_val, {"emoji": "📍"})
+                loc_part = loc_display["emoji"]
+            else:
+                loc_part = "❓"
+            meal_str = " ".join(meal_parts) if meal_parts else "*(no meals)*"
+            fields.append({
+                "name": name,
+                "value": f"{meal_str}  {loc_part}",
+                "inline": True,
+            })
+        if len(members) > 25:
+            fields.append({
+                "name": "\u200b",
+                "value": f"*…and {len(members) - 25} more member(s)*",
+                "inline": False,
+            })
+
     return {
         "title": f"📊 Team Summary — {team_name}",
         "description": "\n".join(parts),
         "fields": fields,
         "color": 0x5865F2,
-        "footer": {"text": "Showing employees who have submitted data for this date"},
+        "footer": {"text": "Showing all team members • ❓ = no response yet"},
     }
 
 

--- a/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
@@ -18,8 +18,11 @@ class GoogleChatRenderer(UIRenderer):
         target_date: date,
         meals: Dict[MealType, Optional[MealParticipation]],
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
         lines = [f"🍽️ *Meal Participation — {format_date_display(target_date)}*"]
+        if team:
+            lines.append(f"🏷️ Team: {team}")
         if confirmation:
             lines.append(confirmation)
         for meal_type, record in meals.items():
@@ -36,8 +39,11 @@ class GoogleChatRenderer(UIRenderer):
         target_date: date,
         current: WorkLocationType,
         confirmation: Optional[str] = None,
+        team: Optional[str] = None,
     ) -> Dict[str, Any]:
         widgets = []
+        if team:
+            widgets.append({"textParagraph": {"text": f"🏷️ Team: {team}"}})
         if confirmation:
             widgets.append({"textParagraph": {"text": confirmation}})
 
@@ -182,12 +188,37 @@ class GoogleChatRenderer(UIRenderer):
         team_name: str,
         summary: Dict[str, Any],
     ) -> Dict[str, Any]:
-        widgets = _build_summary_widgets(summary)
+        sections = [{"widgets": _build_summary_widgets(summary)}]
+
+        members = summary.get("members", [])
+        if members:
+            member_widgets = []
+            for member in members:
+                name = member.get("display_name") or member.get("user_id", "Unknown")
+                meal_parts = []
+                for meal_type, is_in in member.get("meals", {}).items():
+                    display = MEAL_DISPLAY.get(meal_type, {"label": meal_type.value, "emoji": "🍽️"})
+                    meal_parts.append(f"{display['emoji']}{'✅' if is_in else '❌'}")
+                loc_val = member.get("location")
+                if loc_val:
+                    loc_display = LOCATION_DISPLAY.get(loc_val, {"emoji": "📍", "label": str(loc_val)})
+                    loc_part = f"{loc_display['emoji']} {loc_display['label']}"
+                else:
+                    loc_part = "❓ No response"
+                bottom = ((" ".join(meal_parts) + "  ") if meal_parts else "") + loc_part
+                member_widgets.append({
+                    "decoratedText": {
+                        "text": name,
+                        "bottomLabel": bottom,
+                    }
+                })
+            sections.append({"header": "👤 Member Details", "widgets": member_widgets})
+
         return _wrap_card(
             card_id="team_summary",
             title=f"📊 Team Summary — {team_name}",
             subtitle=format_date_display(target_date),
-            sections=[{"widgets": widgets}],
+            sections=sections,
         )
 
     def render_headcount_summary(

--- a/Task2_mhp_discord-bot/backend/src/handlers/headcount_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/headcount_handler.py
@@ -35,7 +35,7 @@ def handle_team_summary(
                 "You are not assigned to a team. Ask an admin to assign you to a team."
             )
 
-        summary = headcount_service.get_team_summary(target_date, team_name)
+        summary = headcount_service.get_team_member_details(target_date, team_name)
         return renderer.render_team_summary(target_date, team_name, summary)
 
     except Exception as e:

--- a/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/location_handler.py
@@ -33,7 +33,7 @@ def handle_work_location(
 
         record = location_service.get_user_location_for_date(interaction.user.user_id, target_date)
         current = location_service.get_current_location(record)
-        return renderer.render_location_status(interaction.user.user_id, target_date, current)
+        return renderer.render_location_status(interaction.user.user_id, target_date, current, team=interaction.user.team)
 
     except Exception as e:
         logger.exception("Error handling work-location: %s", e)
@@ -82,7 +82,7 @@ def handle_location_set(
         loc_display_info = location_service.get_location_display_info(location)
         confirmation = f"Updated → {loc_display_info['emoji']} **{loc_display_info['label']}**"
         status = renderer.render_location_status(
-            interaction.user.user_id, target_date, location, confirmation=confirmation
+            interaction.user.user_id, target_date, location, confirmation=confirmation, team=interaction.user.team
         )
         return renderer.render_update(status)
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/meal_handler.py
@@ -32,7 +32,7 @@ def handle_meal_update(
             return renderer.render_error(error_msg)
 
         meals = meal_service.get_user_meals_for_date(interaction.user.user_id, target_date)
-        return renderer.render_meal_status(interaction.user.user_id, target_date, meals)
+        return renderer.render_meal_status(interaction.user.user_id, target_date, meals, team=interaction.user.team)
 
     except Exception as e:
         logger.exception(f"Error handling meal-update: {e}")
@@ -80,7 +80,7 @@ def handle_meal_toggle(
             f"Click a button below to toggle your participation for each meal."
         )
 
-        status = renderer.render_meal_status(interaction.user.user_id, target_date, updated_meals, confirmation)
+        status = renderer.render_meal_status(interaction.user.user_id, target_date, updated_meals, confirmation, team=interaction.user.team)
         return renderer.render_update(status)
 
     except Exception as e:

--- a/Task2_mhp_discord-bot/backend/src/services/headcount_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/headcount_service.py
@@ -33,6 +33,42 @@ class HeadcountService:
             "total_responding": len(user_ids),
         }
 
+    def get_team_member_details(self, target_date: date, team_name: str) -> Dict[str, Any]:
+        """Aggregate summary + per-member participation detail for a team on a given date."""
+        summary = self.get_team_summary(target_date, team_name)
+
+        meals = self.storage.get_meals_for_date_and_team(target_date, team_name)
+        locations = self.storage.get_locations_for_date_and_team(target_date, team_name)
+
+        meal_map: Dict[str, dict] = defaultdict(dict)
+        for m in meals:
+            meal_map[m.user_id][m.meal_type] = m.is_participating
+
+        loc_map: Dict[str, Any] = {loc.user_id: loc.location for loc in locations}
+
+        users = self.storage.get_users_by_team(team_name)
+        members = []
+        for u in users:
+            members.append({
+                "user_id": u.user_id,
+                "display_name": u.display_name or u.username,
+                "meals": meal_map.get(u.user_id, {}),
+                "location": loc_map.get(u.user_id),
+            })
+
+        # Include users who responded but aren't in the user roster yet
+        roster_ids = {u.user_id for u in users}
+        for uid in (set(meal_map) | set(loc_map)) - roster_ids:
+            members.append({
+                "user_id": uid,
+                "display_name": uid,
+                "meals": meal_map.get(uid, {}),
+                "location": loc_map.get(uid),
+            })
+
+        summary["members"] = members
+        return summary
+
     def get_headcount_summary(
         self, target_date: date, team_filter: Optional[str] = None
     ) -> Dict[str, Any]:

--- a/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
+++ b/Task2_mhp_discord-bot/backend/src/storage/dynamodb.py
@@ -115,6 +115,9 @@ class DynamoDBStorage:
             print(f"Error listing users: {e}")
         return users
 
+    def get_users_by_team(self, team_name: str) -> list[User]:
+        return [u for u in self.get_all_users() if u.team == team_name]
+
     # ── External Identity ────────────────────────────────────────────────────
 
     def put_identity(self, identity: ExternalIdentity) -> None:


### PR DESCRIPTION
## Related Issues
* Closes #27

## Summary
Implements team-based visibility so employees see their team in meal and location responses, and Team Leads can see per-member participation status in `/team-summary`.

## Dependencies
- Requires PR #59

## Changes
- **`storage/dynamodb.py`**: added `get_users_by_team(team_name)`: filters `get_all_users()` by team attribute to return the team roster
- **`services/headcount_service.py`**: added `get_team_member_details(target_date, team_name)`: extends the aggregate summary with a `members` list showing each team member's per-meal opted-in/out status and work location; includes roster members who haven't responded yet
- **`handlers/headcount_handler.py`**: `handle_team_summary` now calls `get_team_member_details()` instead of `get_team_summary()` to include member details
- **`handlers/meal_handler.py`** and **`handlers/location_handler.py`**: pass `team=interaction.user.team` to all `render_meal_status` / `render_location_status` call sites
- **`adapters/base.py`**: added optional `team: Optional[str] = None` parameter to `render_meal_status` and `render_location_status` abstract methods
- **`adapters/discord/renderer.py`**: meal and location embeds show `🏷️ Team: {team}` in the footer; `render_team_summary` embed adds a **👤 Member Details** section with per-member meal icons and location (capped at 25, with overflow notice)
- **`adapters/google_chat/renderer.py`**: meal status prepends a `🏷️ Team: {team}` line; location status card adds a team `textParagraph` widget; `render_team_summary` card adds a **👤 Member Details** section with one `decoratedText` widget per member

## Context
Issue 2.8 defines team-based visibility: employees should see which team they belong to in bot responses, and Team Leads should be able to see which specific team members have responded and their status, not just aggregate totals. The commands and team-scoping logic were already in place in Issue 2.6; this PR adds the display layer (the team name in responses) and the per-member detail view in `/team-summary`.

## How to Test (if applicable)
1. Run `/meal-update` as an employee with a team role assigned, confirm the embed footer shows `🏷️ Team: <team-name>`
2. Run `/work-location`: same footer check
3. Run `/team-summary` as a Team Lead, confirm the response shows aggregate totals followed by a **Member Details** section listing each team member with their meal icons and location
4. Run `/team-summary` for a team with no records, confirm all members appear with ❓ location and no meal icons

[Headcount Summary Lambda Link](https://ap-south-1.console.aws.amazon.com/lambda/home?region=ap-south-1#/functions/trainee-2026-niloy-mhp-headcount?tab=code)

## Checklist (select options which are applicable)
- [x] Code builds successfully
- [x] No breaking changes