### PR TITLE
PR 31: Implement Policy Refinements System for Issue #2.14

### DIFF
--- a/Task2_mhp_discord-bot/backend/infrastructure/template.yaml
+++ b/Task2_mhp_discord-bot/backend/infrastructure/template.yaml
@@ -144,7 +144,7 @@ Resources:
                   - dynamodb:PutItem
                   - dynamodb:UpdateItem
                 Resource:
-                  - !GetAtt MHPTable.Arn
+                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${DynamoDBTableName}
 
   # Feature role: DynamoDB + S3 (used by meal, location, override Lambdas)
   FeatureExecutionRole:

--- a/Task2_mhp_discord-bot/backend/src/adapters/base.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/base.py
@@ -91,6 +91,24 @@ class UIRenderer(ABC):
     ) -> Dict[str, Any]:
         """Return a response payload showing full headcount summary with optional team breakdown."""
 
+    # ── Policy ────────────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def render_policy_view(
+        self,
+        policies: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Return a response payload showing current policy settings."""
+
+    @abstractmethod
+    def render_policy_set_confirmation(
+        self,
+        setting: str,
+        old_value: str,
+        new_value: str,
+    ) -> Dict[str, Any]:
+        """Return a confirmation payload after a policy update."""
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     @abstractmethod

--- a/Task2_mhp_discord-bot/backend/src/adapters/discord/ingress_adapter.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/discord/ingress_adapter.py
@@ -58,12 +58,23 @@ def _parse_command_options(data: Dict[str, Any]) -> Dict[str, Any]:
     result: Dict[str, Any] = {}
 
     for opt in options_list:
-        result[opt["name"]] = opt["value"]
-        if opt.get("type") == 6:  # USER option type
-            user_id_val = opt["value"]
-            if user_id_val in resolved.get("users", {}):
-                result[f"_resolved_user_{opt['name']}"] = resolved["users"][user_id_val]
-            if user_id_val in resolved.get("members", {}):
-                result[f"_resolved_member_{opt['name']}"] = resolved["members"][user_id_val]
+        if opt.get("type") == 1:  # SUB_COMMAND
+            result["_subcommand"] = opt["name"]
+            for sub_opt in opt.get("options", []):
+                result[sub_opt["name"]] = sub_opt["value"]
+                if sub_opt.get("type") == 6:
+                    _resolve_user(sub_opt, resolved, result)
+        else:
+            result[opt["name"]] = opt["value"]
+            if opt.get("type") == 6:  # USER option type
+                _resolve_user(opt, resolved, result)
 
     return result
+
+
+def _resolve_user(opt: Dict[str, Any], resolved: Dict[str, Any], result: Dict[str, Any]) -> None:
+    user_id_val = opt["value"]
+    if user_id_val in resolved.get("users", {}):
+        result[f"_resolved_user_{opt['name']}"] = resolved["users"][user_id_val]
+    if user_id_val in resolved.get("members", {}):
+        result[f"_resolved_member_{opt['name']}"] = resolved["members"][user_id_val]

--- a/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/discord/renderer.py
@@ -122,6 +122,42 @@ class DiscordRenderer(UIRenderer):
             "data": {"embeds": [embed], "flags": EPHEMERAL_FLAG},
         }
 
+    # ── Policy ────────────────────────────────────────────────────────────────
+
+    def render_policy_view(self, policies: Dict[str, str]) -> Dict[str, Any]:
+        from src.services.policy_service import POLICY_DISPLAY
+        fields = []
+        for key, value in policies.items():
+            label = POLICY_DISPLAY.get(key, key)
+            fields.append({"name": label, "value": f"**{value}**", "inline": True})
+        embed = {
+            "title": "Policy Settings",
+            "fields": fields,
+            "color": 0x5865F2,
+            "footer": {"text": "Use /policy set <setting> <value> to update"},
+        }
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"embeds": [embed], "flags": EPHEMERAL_FLAG},
+        }
+
+    def render_policy_set_confirmation(
+        self, setting: str, old_value: str, new_value: str,
+    ) -> Dict[str, Any]:
+        from src.services.policy_service import POLICY_DISPLAY
+        label = POLICY_DISPLAY.get(setting, setting)
+        embed = {
+            "title": "Policy Updated",
+            "fields": [
+                {"name": label, "value": f"~~{old_value}~~ **{new_value}**"},
+            ],
+            "color": 0x57F287,
+        }
+        return {
+            "type": RESPONSE_CHANNEL_MESSAGE,
+            "data": {"embeds": [embed], "flags": EPHEMERAL_FLAG},
+        }
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     def render_success(self, message: str) -> Dict[str, Any]:

--- a/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
+++ b/Task2_mhp_discord-bot/backend/src/adapters/google_chat/renderer.py
@@ -224,6 +224,34 @@ class GoogleChatRenderer(UIRenderer):
             sections=sections,
         )
 
+    # ── Policy ────────────────────────────────────────────────────────────────
+
+    def render_policy_view(self, policies: Dict[str, str]) -> Dict[str, Any]:
+        from src.services.policy_service import POLICY_DISPLAY
+        widgets = []
+        for key, value in policies.items():
+            label = POLICY_DISPLAY.get(key, key)
+            widgets.append({"decoratedText": {
+                "text": label,
+                "bottomLabel": value,
+            }})
+        widgets.append({"textParagraph": {
+            "text": "<i>Use <b>/policy set &lt;setting&gt; &lt;value&gt;</b> to update</i>",
+        }})
+        return _wrap_card(
+            card_id="policy_view",
+            title="Policy Settings",
+            subtitle="Current configuration",
+            sections=[{"widgets": widgets}],
+        )
+
+    def render_policy_set_confirmation(
+        self, setting: str, old_value: str, new_value: str,
+    ) -> Dict[str, Any]:
+        from src.services.policy_service import POLICY_DISPLAY
+        label = POLICY_DISPLAY.get(setting, setting)
+        return _render_text(f"✅ **{label}** updated: {old_value} → **{new_value}**")
+
     # ── Utilities ─────────────────────────────────────────────────────────────
 
     def render_success(self, message: str) -> Dict[str, Any]:

--- a/Task2_mhp_discord-bot/backend/src/handlers/auth.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/auth.py
@@ -59,6 +59,7 @@ COMMAND_ROLE_REQUIREMENTS = {
     "headcount-summary": UserRole.ADMIN,
     "override-update": UserRole.TEAM_LEAD,
     "generate-summary": UserRole.ADMIN,
+    "policy": UserRole.ADMIN,
 }
 
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/google_chat_ingress.py
@@ -31,6 +31,7 @@ from src.handlers.override_handler import (
 )
 from src.handlers.link_handler import handle_link_identity
 from src.handlers.headcount_handler import handle_team_summary, handle_headcount_summary
+from src.handlers.policy_handler import handle_policy
 from src.config import settings
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,8 @@ def _route_command(normalized) -> Dict[str, Any]:
         return handle_team_summary(normalized, _renderer)
     if cmd == "headcount-summary":
         return handle_headcount_summary(normalized, _renderer)
+    if cmd == "policy":
+        return handle_policy(normalized, _renderer)
     return _renderer.render_error(f"Unknown command: `{cmd}`")
 
 

--- a/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/ingress.py
@@ -28,6 +28,7 @@ from src.handlers.override_handler import (
 )
 from src.handlers.link_handler import handle_link_identity
 from src.handlers.headcount_handler import handle_team_summary, handle_headcount_summary
+from src.handlers.policy_handler import handle_policy
 from src.handlers import dispatcher
 from src.config import settings
 
@@ -86,6 +87,8 @@ def _route_inprocess(normalized, interaction_type: int) -> Dict[str, Any]:
             return handle_team_summary(normalized, _renderer)
         if cmd == "headcount-summary":
             return handle_headcount_summary(normalized, _renderer)
+        if cmd == "policy":
+            return handle_policy(normalized, _renderer)
         return {
             "type": RESPONSE_CHANNEL_MESSAGE,
             "data": {

--- a/Task2_mhp_discord-bot/backend/src/handlers/policy_handler.py
+++ b/Task2_mhp_discord-bot/backend/src/handlers/policy_handler.py
@@ -1,0 +1,116 @@
+# Handles /policy view and /policy set slash commands
+import json
+import logging
+from typing import Any, Dict
+
+from src.adapters.base import UIRenderer
+from src.adapters.normalized import NormalizedInteraction
+from src.services.policy_service import (
+    POLICY_KEYS,
+    get_all_policies,
+    set_policy,
+    validate_policy_value,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def handle_policy(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    """Top-level dispatcher: routes to view or set based on subcommand."""
+    # Discord: subcommand stored in _subcommand by ingress adapter
+    subcommand = interaction.options.get("_subcommand")
+
+    # Google Chat: /policy view or /policy set cutoff-time 22:00
+    if not subcommand:
+        args = interaction.options.get("_args", [])
+        subcommand = args[0] if args else "view"
+
+    if subcommand == "set":
+        return handle_policy_set(interaction, renderer)
+    return handle_policy_view(interaction, renderer)
+
+
+def handle_policy_view(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    try:
+        policies = get_all_policies()
+        return renderer.render_policy_view(policies)
+    except Exception as e:
+        logger.exception("Error handling policy view: %s", e)
+        return renderer.render_error(
+            "An error occurred while fetching policy settings. Please try again."
+        )
+
+
+def handle_policy_set(
+    interaction: NormalizedInteraction,
+    renderer: UIRenderer,
+) -> Dict[str, Any]:
+    try:
+        # Discord subcommand options
+        setting = interaction.options.get("setting")
+        value = interaction.options.get("value")
+
+        # Google Chat: /policy set cutoff-time 22:00
+        if not setting:
+            args = interaction.options.get("_args", [])
+            # args[0] = "set", args[1] = setting name, args[2+] = value
+            if len(args) >= 3:
+                setting = args[1]
+                value = " ".join(args[2:])
+            elif len(args) == 2:
+                setting = args[1]
+
+        if not setting:
+            return renderer.render_error(
+                "Please specify a setting to update. "
+                f"Valid settings: {', '.join(f'`{k}`' for k in POLICY_KEYS)}."
+            )
+
+        # Normalize hyphens to underscores (cutoff-time → cutoff_time)
+        setting = setting.replace("-", "_")
+
+        if setting not in POLICY_KEYS:
+            return renderer.render_error(
+                f"Unknown policy: `{setting}`. "
+                f"Valid policies: {', '.join(f'`{k}`' for k in POLICY_KEYS)}."
+            )
+
+        if not value:
+            return renderer.render_error(
+                f"Please provide a value for `{setting}`."
+            )
+
+        # Get old value for confirmation display
+        old_policies = get_all_policies()
+        old_value = old_policies.get(setting, "")
+
+        # Validate the new value
+        is_valid, error_msg = validate_policy_value(setting, value)
+        if not is_valid:
+            return renderer.render_error(error_msg)
+
+        # For active_meal_types, store as JSON array
+        if setting == "active_meal_types":
+            types = [t.strip() for t in value.split(",") if t.strip()]
+            value = json.dumps(types)
+
+        set_policy(setting, value)
+
+        # Format display value for confirmation
+        display_value = value
+        if setting == "active_meal_types":
+            display_value = ", ".join(json.loads(value))
+
+        return renderer.render_policy_set_confirmation(setting, old_value, display_value)
+
+    except Exception as e:
+        logger.exception("Error handling policy set: %s", e)
+        return renderer.render_error(
+            "An error occurred while updating the policy. Please try again."
+        )

--- a/Task2_mhp_discord-bot/backend/src/services/location_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/location_service.py
@@ -96,7 +96,8 @@ class LocationService:
     def _check_wfh_cap(
         self, discord_id: str, target_date: date
     ) -> tuple[bool, str | None]:
-        cap = settings.WFH_MONTHLY_CAP
+        from src.services.policy_service import get_wfh_monthly_cap
+        cap = get_wfh_monthly_cap()
         if cap <= 0:
             return False, None  # disabled
 

--- a/Task2_mhp_discord-bot/backend/src/services/meal_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/meal_service.py
@@ -31,7 +31,8 @@ class MealService:
         self.storage = storage or default_storage
 
     def get_available_meal_types(self) -> list[MealType]:
-        return list(DEFAULT_MEAL_TYPES)
+        from src.services.policy_service import get_active_meal_types
+        return get_active_meal_types()
 
     def get_user_meals_for_date(
         self, discord_id: str, target_date: date

--- a/Task2_mhp_discord-bot/backend/src/services/policy_service.py
+++ b/Task2_mhp_discord-bot/backend/src/services/policy_service.py
@@ -1,0 +1,149 @@
+# Centralized policy read/write with in-memory caching.
+# Falls back to settings.* env var defaults when no DynamoDB policy exists.
+import json
+import logging
+from datetime import datetime
+from typing import Optional
+
+from src.config import settings
+from src.models import MealType, Policy
+
+logger = logging.getLogger(__name__)
+
+# Policy keys recognized by the system
+POLICY_KEYS = ["cutoff_time", "wfh_monthly_cap", "forward_planning_days", "active_meal_types"]
+
+# Display-friendly names for /policy view
+POLICY_DISPLAY = {
+    "cutoff_time": "Cutoff Time",
+    "wfh_monthly_cap": "WFH Monthly Cap",
+    "forward_planning_days": "Forward Planning Days",
+    "active_meal_types": "Active Meal Types",
+}
+
+# Hardcoded fallback for active meal types (matches meal_service.DEFAULT_MEAL_TYPES)
+_DEFAULT_MEAL_TYPES = [MealType.LUNCH, MealType.SNACKS]
+
+# ── In-memory cache (per Lambda container) ──────────────────────────────────
+
+_policy_cache: dict[str, Optional[str]] = {}
+
+
+def _get_raw(policy_name: str) -> Optional[str]:
+    """Read a policy value from cache or DynamoDB. Returns None if not set."""
+    if policy_name not in _policy_cache:
+        from src.storage.dynamodb import storage
+        policy = storage.get_policy(policy_name)
+        _policy_cache[policy_name] = policy.value if policy else None
+    return _policy_cache[policy_name]
+
+
+def invalidate_cache(name: Optional[str] = None) -> None:
+    """Clear cached policy values. Pass name to clear one, or None to clear all."""
+    if name:
+        _policy_cache.pop(name, None)
+    else:
+        _policy_cache.clear()
+
+
+# ── Typed accessors (DynamoDB → env var fallback) ────────────────────────────
+
+def get_cutoff_time() -> str:
+    return _get_raw("cutoff_time") or settings.CUTOFF_TIME
+
+
+def get_wfh_monthly_cap() -> int:
+    raw = _get_raw("wfh_monthly_cap")
+    if raw is not None:
+        try:
+            return int(raw)
+        except ValueError:
+            logger.warning("Invalid wfh_monthly_cap policy value: %s", raw)
+    return settings.WFH_MONTHLY_CAP
+
+
+def get_forward_planning_days() -> int:
+    raw = _get_raw("forward_planning_days")
+    if raw is not None:
+        try:
+            return int(raw)
+        except ValueError:
+            logger.warning("Invalid forward_planning_days policy value: %s", raw)
+    return settings.FORWARD_PLANNING_DAYS
+
+
+def get_active_meal_types() -> list[MealType]:
+    raw = _get_raw("active_meal_types")
+    if raw:
+        try:
+            return [MealType(v) for v in json.loads(raw)]
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning("Invalid active_meal_types policy: %s", e)
+    return list(_DEFAULT_MEAL_TYPES)
+
+
+def get_all_policies() -> dict[str, str]:
+    """Return all policy values (resolved with defaults) for /policy view."""
+    return {
+        "cutoff_time": get_cutoff_time(),
+        "wfh_monthly_cap": str(get_wfh_monthly_cap()),
+        "forward_planning_days": str(get_forward_planning_days()),
+        "active_meal_types": ", ".join(m.value for m in get_active_meal_types()),
+    }
+
+
+# ── Write ────────────────────────────────────────────────────────────────────
+
+def set_policy(name: str, value: str) -> None:
+    """Write a policy to DynamoDB and invalidate the local cache."""
+    from src.storage.dynamodb import storage
+    storage.put_policy(Policy(name=name, value=value, updated_at=datetime.utcnow()))
+    invalidate_cache(name)
+
+
+# ── Validation helpers (for /policy set) ─────────────────────────────────────
+
+def validate_policy_value(name: str, value: str) -> tuple[bool, Optional[str]]:
+    """Validate a policy value before writing. Returns (ok, error_message)."""
+    if name == "cutoff_time":
+        parts = value.split(":")
+        if len(parts) != 2:
+            return False, "Cutoff time must be in HH:MM format."
+        try:
+            h, m = int(parts[0]), int(parts[1])
+        except ValueError:
+            return False, "Cutoff time must be in HH:MM format with numeric values."
+        if not (0 <= h <= 23 and 0 <= m <= 59):
+            return False, "Hours must be 0-23 and minutes must be 0-59."
+        return True, None
+
+    if name == "wfh_monthly_cap":
+        try:
+            cap = int(value)
+        except ValueError:
+            return False, "WFH monthly cap must be a non-negative integer."
+        if cap < 0:
+            return False, "WFH monthly cap must be a non-negative integer."
+        return True, None
+
+    if name == "forward_planning_days":
+        try:
+            days = int(value)
+        except ValueError:
+            return False, "Forward planning days must be an integer between 1 and 30."
+        if not (1 <= days <= 30):
+            return False, "Forward planning days must be between 1 and 30."
+        return True, None
+
+    if name == "active_meal_types":
+        types = [t.strip() for t in value.split(",") if t.strip()]
+        if not types:
+            return False, "At least one meal type is required."
+        valid_values = [m.value for m in MealType]
+        for t in types:
+            if t not in valid_values:
+                return False, f"Unknown meal type: `{t}`. Valid types: {', '.join(f'`{v}`' for v in valid_values)}."
+        # Store as JSON array
+        return True, None
+
+    return False, f"Unknown policy: `{name}`. Valid policies: {', '.join(f'`{k}`' for k in POLICY_KEYS)}."

--- a/Task2_mhp_discord-bot/backend/src/utils.py
+++ b/Task2_mhp_discord-bot/backend/src/utils.py
@@ -51,7 +51,8 @@ def _parse_cutoff_time(raw: str) -> tuple[int, int]:
 
 
 def get_cutoff_datetime(target_date: date) -> datetime:
-    hour, minute = _parse_cutoff_time(settings.CUTOFF_TIME)
+    from src.services.policy_service import get_cutoff_time
+    hour, minute = _parse_cutoff_time(get_cutoff_time())
     return datetime(
         target_date.year, target_date.month, target_date.day,
         hour, minute, 0,
@@ -71,7 +72,8 @@ def is_past_date(target_date: date) -> bool:
 
 def is_within_forward_window(target_date: date) -> bool:
     today = get_dhaka_today()
-    max_date = today + timedelta(days=settings.FORWARD_PLANNING_DAYS)
+    from src.services.policy_service import get_forward_planning_days
+    max_date = today + timedelta(days=get_forward_planning_days())
     return target_date <= max_date
 
 def validate_date_for_update(target_date: date) -> tuple[bool, str | None]:
@@ -81,13 +83,13 @@ def validate_date_for_update(target_date: date) -> tuple[bool, str | None]:
     if is_past_cutoff(target_date):
         return False, (
             f"Updates for {target_date.isoformat()} are closed. "
-            f"The cutoff time is {settings.CUTOFF_TIME} (Asia/Dhaka)."
+            f"The cutoff time is {get_cutoff_time()} (Asia/Dhaka)."
         )
 
     if not is_within_forward_window(target_date):
         return False, (
-            f"Cannot update dates more than {settings.FORWARD_PLANNING_DAYS} days ahead. "
-            f"Maximum allowed date: {(get_dhaka_today() + timedelta(days=settings.FORWARD_PLANNING_DAYS)).isoformat()}."
+            f"Cannot update dates more than {get_forward_planning_days()} days ahead. "
+            f"Maximum allowed date: {(get_dhaka_today() + timedelta(days=get_forward_planning_days())).isoformat()}."
         )
 
     return True, None


### PR DESCRIPTION
## Related Issues

* Fixes #33

## Summary

Adds a `/policy` admin command for viewing and updating operational settings (cutoff time, WFH cap, forward planning days, active meal types) at runtime via DynamoDB, replacing hardcoded environment variable reads with a centralized policy service.

## Dependencies

- _(none needed)_

## Changes

- Created `src/services/policy_service.py` — centralized policy read/write with in-memory per-key caching, typed accessors (`get_cutoff_time`, `get_wfh_monthly_cap`, `get_forward_planning_days`, `get_active_meal_types`), validation, and DynamoDB fallback to env var defaults
- Created `src/handlers/policy_handler.py` — `/policy view` and `/policy set` command handlers with per-type input validation and subcommand dispatch
- Added `render_policy_view` and `render_policy_set_confirmation` abstract methods to `src/adapters/base.py`
- Implemented policy rendering in `src/adapters/discord/renderer.py` (embeds with inline fields, strikethrough old values) and `src/adapters/google_chat/renderer.py` (Cards v2 decoratedText widgets)
- Enhanced `src/adapters/discord/ingress_adapter.py` to parse Discord subcommands (type 1) — sets `options["_subcommand"]` and flattens nested options
- Added `"policy": UserRole.ADMIN` to `COMMAND_ROLE_REQUIREMENTS` in `src/handlers/auth.py`
- Wired `/policy` command routing in `src/handlers/ingress.py` and `src/handlers/google_chat_ingress.py`
- Replaced `settings.CUTOFF_TIME` and `settings.FORWARD_PLANNING_DAYS` reads in `src/utils.py` with policy service calls
- Replaced `settings.WFH_MONTHLY_CAP` in `src/services/location_service.py` with `get_wfh_monthly_cap()`
- Changed `src/services/meal_service.py` `get_available_meal_types()` to use `get_active_meal_types()` from the policy service

## Context

Operational config values (cutoff time, WFH cap, forward planning days, active meal types) were hardcoded as Lambda environment variables, requiring a redeploy to change. This makes it possible for admins to update these settings at runtime via `/policy set`, with values stored in DynamoDB (`POLICY#<name>` key pattern) and cached in-memory per Lambda invocation. Env var values serve as fallback defaults when no DynamoDB policy exists — no breaking changes.

## How to Test (if applicable)

1. Check code changes
2. Deploy and run `/policy view` on Discord — verify embed shows all 4 settings with current (default) values
3. Run `/policy set cutoff-time 22:00` — verify confirmation embed and that subsequent meal/location updates use the new cutoff
4. Run `/policy set active-meal-types lunch, snacks, iftar` — verify `/meal-update` now shows 3 meal types
5. Test validation: `/policy set cutoff-time 25:00` should return an error
6. Test on Google Chat: `/policy view` and `/policy set wfh-monthly-cap 10`

## Checklist (select options which are applicable)

- [x] Code builds successfully
- [x] Tests added or updated
- [ ] Documentation updated/added
- [x] No breaking changes

